### PR TITLE
docs: mathematical correctness review of SemiExplicitIntegrator.md

### DIFF
--- a/theory/SemiExplicitIntegrator.md
+++ b/theory/SemiExplicitIntegrator.md
@@ -163,9 +163,9 @@ Therefore $Df_0 = 2 \cdot 2I_{2d} = 4I_{2d}$, giving the Newton step $(Df_0)^{-1
 
 **Stopping criterion:**
 
-$$\|\mu^{(N+1)} - \mu^{(N)}\| < \varepsilon \quad \text{and} \quad \|f(\mu^{(N+1)})\| < \varepsilon$$
+$$\left\|\mu^{(N+1)} - \mu^{(N)}\right\| < \varepsilon$$
 
-The first condition checks iteration stationarity; the second verifies the constraint is actually satisfied.
+and set $\mu = \mu^{(N)}$.
 
 ## Broyden's Method (Alternative)
 
@@ -183,7 +183,7 @@ This allows efficient computation of $J_k^{-1}$ from $J_{k-1}^{-1}$ in $O(n^2)$ 
 
 $$\mu^{(k+1)} = \mu^{(k)} - J_k^{-1} f(\mu^{(k)})$$
 
-where $J_0 = 4I_{2d}$ and $J_k$ is the rank-1 update:
+where $J_0 = 4I_{2d}$ and $J_k$ is maintained via the rank-1 update:
 
 $$J_k = J_{k-1} + \frac{(\Delta f^{(k)} - J_{k-1}\Delta\mu^{(k)})(\Delta\mu^{(k)})^T}{\|\Delta\mu^{(k)}\|^2}$$
 
@@ -193,6 +193,10 @@ with:
 - $(\Delta\mu^{(k)})^T \in \mathbb{R}^{1 \times 2d}$ (row vector)
 - The numerator is an **outer product** producing a $2d \times 2d$ matrix
 
+Applying the Sherman-Morrison formula to this rank-1 update yields the direct inverse update (maintained iteratively, never inverting $J_k$ explicitly):
+
+$$J_k^{-1} = J_{k-1}^{-1} + \frac{\Delta\mu^{(k)} - J_{k-1}^{-1}\Delta f^{(k)}}{(\Delta\mu^{(k)})^T J_{k-1}^{-1}\Delta f^{(k)}} \left(\Delta\mu^{(k)}\right)^T J_{k-1}^{-1}$$
+
 ## Key Properties
 
 - Symplectic in original phase space (preserves $dq \wedge dp$)
@@ -200,7 +204,7 @@ with:
 - Symmetric if $\hat{\Phi}$ is symmetric
 - Phase space defect $\|(q,p) - (x,y)\| \sim \varepsilon$ (tolerance)
 - Requires few iterations (typically 1-3) for small $\Delta t$
-- Computational cost scales as $O(d)$ per iteration for the projection step
+- Projection step overhead per Newton iteration is $O(d)$ (one $\hat{\Phi}$ evaluation plus sparse matrix-vector products with $A$, $A^T$)
 
 ## Reference
 


### PR DESCRIPTION
## Summary

- Removes spurious second stopping condition `‖f(μ)‖ < ε` from Newton iteration — paper eq. (24) specifies only the stationarity criterion `‖μ^(N+1)−μ^(N)‖ < ε`
- Adds the missing explicit Broyden inverse update `J_k⁻¹` (paper eq. 25b), derived via Sherman–Morrison; without it the section claimed O(n²) efficiency but provided no formula to achieve it
- Clarifies the O(d) cost claim to accurately reflect that it is the overhead per Newton iteration beyond the `Φ̂` evaluation, not the total per-iteration cost

All other equations verified correct against Jayawardana & Ohsawa (2021) arXiv:2111.10915.

## Test plan
- [ ] Theory doc only — no code changes, no tests needed
- [ ] Equations verified page-by-page against the source PDF

🤖 Generated with [Claude Code](https://claude.ai/claude-code)