### PR TITLE
refactor: rename Weber*{System,Problem,Solution,Integrator} to Hamiltonian*

### DIFF
--- a/docs/src/api/problem.md
+++ b/docs/src/api/problem.md
@@ -3,7 +3,7 @@
 ## Problem definition
 
 ```@docs
-WeberProblem
+HamiltonianProblem
 ```
 
 ## Optional features

--- a/docs/src/api/solver.md
+++ b/docs/src/api/solver.md
@@ -17,7 +17,7 @@ solve!
 ## Types
 
 ```@docs
-WeberIntegrator
-WeberSolution
+HamiltonianIntegrator
+HamiltonianSolution
 SymmetricProjectionIntegrator
 ```

--- a/docs/src/api/system.md
+++ b/docs/src/api/system.md
@@ -1,10 +1,10 @@
 # System
 
-The `WeberSystem` encapsulates the symbolic and compiled Weber Hamiltonian for
+The `HamiltonianSystem` encapsulates the symbolic and compiled Weber Hamiltonian for
 a given `(n_particles, dims)` configuration. Construct it once and reuse it
-across many `WeberProblem` instances.
+across many `HamiltonianProblem` instances.
 
 ```@docs
-WeberSystem
-WeberSystem(::Int, ::Int)
+HamiltonianSystem
+HamiltonianSystem(::Int, ::Int)
 ```

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -9,8 +9,8 @@ Reference for contributors, developers, and AI agents working with WeberElectrod
 ### Source files (`src/`)
 
 - `WeberElectrodynamics.jl` — Module definition, exports, extension stubs (`plot_*`, `animate_weber`)
-- `weber_system.jl` — `WeberSystem`: uses Symbolics.jl to build the Weber Hamiltonian symbolically, then compiles `dq_dt`, `dp_dt`, and `hamiltonian` functions via `build_function`
-- `types.jl` — All core structs: `WeberProblem`, `WeberSolution`, `WeberIntegrator`, `SymmetricProjectionIntegrator`, `RegularizationOptions`, `ZollnerOptions`, buffer/diagnostics types
+- `hamiltonian_system.jl` — `HamiltonianSystem`: uses Symbolics.jl to build the Weber Hamiltonian symbolically, then compiles `dq_dt`, `dp_dt`, and `hamiltonian` functions via `build_function`
+- `types.jl` — All core structs: `HamiltonianProblem`, `HamiltonianSolution`, `HamiltonianIntegrator`, `SymmetricProjectionIntegrator`, `RegularizationOptions`, `ZollnerOptions`, buffer/diagnostics types
 - `regularization.jl` — Internal helpers: pair distance detection, adjacency graph (BFS), Levi-Civita 2D projection, KS quaternion helpers
 - `solve.jl` — Main integrator: Strang splitting flow, symmetric projection via fixed-point iteration on Lagrange multipliers, regularization dispatch, collision bounce, CommonSolve interface (`init`/`step!`/`solve!`/`solve`)
 - `statistics/` — `energy.jl`, `forces.jl`, `momentum.jl`, `trajectories.jl` — post-solution analysis producing typed data structs
@@ -24,7 +24,7 @@ Reference for contributors, developers, and AI agents working with WeberElectrod
 
 - `test_utils.jl` — Problem builders (`make_weber_problem()`, `make_coulomb_like_problem()`) and reference energy functions; **must be included before other test files**
 - `runtests.jl` — Entry point, includes all test files in order
-- Test files: `test_types.jl`, `test_weber_system.jl`, `test_solve.jl`, `test_statistics.jl`, `test_integration.jl`, `test_physics.jl`, `test_regularization.jl`, `test_zollner.jl`
+- Test files: `test_types.jl`, `test_hamiltonian_system.jl`, `test_solve.jl`, `test_statistics.jl`, `test_integration.jl`, `test_physics.jl`, `test_regularization.jl`, `test_zollner.jl`
 
 ### Examples (`examples/`)
 
@@ -75,7 +75,7 @@ Neither backend regularizes Weber's velocity-dependent force — only the Coulom
 
 ### Collision bounce
 
-- Enabled via `RegularizationOptions(collision_bounce_radius = <r>)` passed to `WeberProblem` (default 0.0 = off)
+- Enabled via `RegularizationOptions(collision_bounce_radius = <r>)` passed to `HamiltonianProblem` (default 0.0 = off)
 - Only valid for ℓ=0 (head-on) collisions
 - Works best with the **unregularized** integrator (symplectic error stays bounded)
 
@@ -83,7 +83,7 @@ Neither backend regularizes Weber's velocity-dependent force — only the Coulom
 
 - `ZollnerOptions(enabled, a)` — mismatch parameter `a`
 - κ_ij = 1+a for unlike-sign charge pairs, 1.0 for like-sign
-- Stored in `WeberProblem.kappas` and appended to the params vector automatically
+- Stored in `HamiltonianProblem.kappas` and appended to the params vector automatically
 
 ### Makie animation extension
 
@@ -93,7 +93,7 @@ Neither backend regularizes Weber's velocity-dependent force — only the Coulom
 
 ### Immutable options pattern
 
-`RegularizationOptions`, `ZollnerOptions` are immutable structs created once per problem. Pass configuration through `WeberProblem` keyword arguments rather than mutating options.
+`RegularizationOptions`, `ZollnerOptions` are immutable structs created once per problem. Pass configuration through `HamiltonianProblem` keyword arguments rather than mutating options.
 
 ---
 

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -6,13 +6,13 @@
 using WeberElectrodynamics
 
 # Build the system (symbolic differentiation happens here — takes a few seconds)
-sys = WeberSystem(2, 2)   # 2 particles, 2D
+sys = HamiltonianSystem(2, 2)   # 2 particles, 2D
 
 # Initial conditions: particles at (±1, 0) with transverse momenta
 q0 = [1.0, 0.0, -1.0, 0.0]
 p0 = [0.0, 0.5,  0.0, -0.5]
 
-prob = WeberProblem(
+prob = HamiltonianProblem(
     sys, (0.0, 10.0), q0, p0;
     masses  = [1.0, 1.0],
     charges = [1.0, -1.0],
@@ -22,7 +22,7 @@ prob = WeberProblem(
 
 sol = solve(prob, SymmetricProjectionIntegrator())
 println(sol)
-# WeberSolution with 1001 timesteps (retcode: Success)
+# HamiltonianSolution with 1001 timesteps (retcode: Success)
 ```
 
 ## Setting up initial conditions
@@ -171,7 +171,7 @@ extensions can be enabled explicitly:
 
 - **[Regularization](regularization.md)** — Levi-Civita / KS handling for
   close encounters. Pass `regularization = RegularizationOptions(enabled = true)`
-  to `WeberProblem`.
+  to `HamiltonianProblem`.
 - **[Zöllner Extension](zollner.md)** — research feature implementing Zöllner's
   electrogravitational mismatch hypothesis. Pass
-  `zollner = ZollnerOptions(enabled = true, a = <value>)` to `WeberProblem`.
+  `zollner = ZollnerOptions(enabled = true, a = <value>)` to `HamiltonianProblem`.

--- a/docs/src/regularization.md
+++ b/docs/src/regularization.md
@@ -21,7 +21,7 @@ apply to the conservative part of the force.
 ## Enabling regularization
 
 ```julia
-prob = WeberProblem(
+prob = HamiltonianProblem(
     sys, tspan, q0, p0;
     masses  = [1.0, 1.0],
     charges = [1.0, -1.0],
@@ -50,7 +50,7 @@ For 3D problems, `:lifted_pair` automatically falls back to `:adaptive_cartesian
 
 ```julia
 # Explicit 3D choice
-prob = WeberProblem(sys, tspan, q0, p0; ...
+prob = HamiltonianProblem(sys, tspan, q0, p0; ...
     regularization = RegularizationOptions(
         enabled = true,
         backend = :adaptive_cartesian,
@@ -72,7 +72,7 @@ r_off = r_off_factor × min_initial_separation   (default factor: 0.25)
 You can override them directly:
 
 ```julia
-prob = WeberProblem(sys, tspan, q0, p0; ...
+prob = HamiltonianProblem(sys, tspan, q0, p0; ...
     regularization = RegularizationOptions(
         enabled = true,
         r_on    = 0.05,
@@ -95,7 +95,7 @@ boundary can be applied before each macro-step. This avoids the non-regularizabl
 ℓ ≠ 0 singularity (where particles reach r = 0 at infinite speed).
 
 ```julia
-prob = WeberProblem(sys, tspan, q0, p0; ...
+prob = HamiltonianProblem(sys, tspan, q0, p0; ...
     regularization = RegularizationOptions(collision_bounce_radius = 0.02),  # reflect at r < 0.02
 )
 ```
@@ -105,7 +105,7 @@ unregularized symplectic integrator keeps energy bounded across the bounce).
 
 ## Diagnostics
 
-Every `WeberSolution` carries a `regularization::RegularizationDiagnostics`
+Every `HamiltonianSolution` carries a `regularization::RegularizationDiagnostics`
 field with step counts, backend used, minimum encounter distance, and more.
 
 ```julia

--- a/docs/src/zollner.md
+++ b/docs/src/zollner.md
@@ -32,7 +32,7 @@ for the full theoretical derivation.
 ## Enabling Zöllner
 
 ```julia
-prob = WeberProblem(
+prob = HamiltonianProblem(
     sys, tspan, q0, p0;
     masses  = [1.0, 1.0],
     charges = [1.0, -1.0],
@@ -49,7 +49,7 @@ prob = WeberProblem(
 Zöllner is fully compatible with regularization:
 
 ```julia
-prob = WeberProblem(sys, tspan, q0, p0; ...
+prob = HamiltonianProblem(sys, tspan, q0, p0; ...
     zollner        = ZollnerOptions(enabled = true, a = 0.01),
     regularization = RegularizationOptions(enabled = true),
 )

--- a/ext/WeberElectrodynamicsMakieExt.jl
+++ b/ext/WeberElectrodynamicsMakieExt.jl
@@ -2,7 +2,7 @@ module WeberElectrodynamicsMakieExt
 
 using WeberElectrodynamics
 using WeberElectrodynamics: @sprintf, norm, dot,
-    WeberProblem, WeberIntegrator, WeberSystem, WeberSolution,
+    HamiltonianProblem, HamiltonianIntegrator, HamiltonianSystem, HamiltonianSolution,
     SymmetricProjectionIntegrator, WeberAlgorithm,
     _pair_index, compute_total_kinetic_energy, compute_pair_weber_components
 using CommonSolve: init, step!
@@ -15,12 +15,12 @@ using Makie
 abstract type AnimationDataSource end
 
 mutable struct StreamingSource <: AnimationDataSource
-    integrator::WeberIntegrator
+    integrator::HamiltonianIntegrator
     total_steps::Int
 end
 
 mutable struct ReplaySource <: AnimationDataSource
-    sol::WeberSolution
+    sol::HamiltonianSolution
     stride::Int
     cursor::Int
 end
@@ -51,7 +51,7 @@ mutable struct RollingBuffer
     particle_p::Dict{Int,Matrix{Float64}}
 end
 
-function RollingBuffer(capacity::Int, prob::WeberProblem)
+function RollingBuffer(capacity::Int, prob::HamiltonianProblem)
     n = prob.system.n_particles
     dims = prob.system.dims
 
@@ -87,7 +87,7 @@ end
 # Per-Step Computation
 # =============================================================================
 
-function _compute_step_energy(q::AbstractVector{Float64}, p::AbstractVector{Float64}, prob::WeberProblem)
+function _compute_step_energy(q::AbstractVector{Float64}, p::AbstractVector{Float64}, prob::HamiltonianProblem)
     masses = prob.masses
     charges = prob.charges
     c = prob.c
@@ -133,7 +133,7 @@ end
 # =============================================================================
 
 function push_step!(buf::RollingBuffer, t::Float64, q::AbstractVector{Float64},
-                    p::AbstractVector{Float64}, prob::WeberProblem)
+                    p::AbstractVector{Float64}, prob::HamiltonianProblem)
     idx = buf.cursor
     dims = prob.system.dims
     n = prob.system.n_particles
@@ -220,7 +220,7 @@ end
 
 mutable struct AnimationState
     source::AnimationDataSource
-    prob::WeberProblem
+    prob::HamiltonianProblem
     buffer::RollingBuffer
     is_playing::Observable{Bool}
     timer::Union{Nothing,Timer}
@@ -237,7 +237,7 @@ mutable struct AnimationState
 
     # For streaming reset
     alg::SymmetricProjectionIntegrator
-    extended_prob::Union{Nothing,WeberProblem}
+    extended_prob::Union{Nothing,HamiltonianProblem}
 
     # Axes for limit reset (mixed Axis / Axis3)
     axes::Vector{Any}
@@ -287,7 +287,7 @@ struct PlotObservables
     step_text::Observable{String}
 end
 
-function _create_observables(prob::WeberProblem)
+function _create_observables(prob::HamiltonianProblem)
     n = prob.system.n_particles
     dims = prob.system.dims
 
@@ -841,7 +841,7 @@ end
 # Integrator Recycling (Streaming)
 # =============================================================================
 
-function _recycle_integrator!(integ::WeberIntegrator)
+function _recycle_integrator!(integ::HamiltonianIntegrator)
     span = integ.t_end - integ.t_history[1]
     integ.step_count = 0
     integ.t_end = integ.t + span
@@ -906,9 +906,9 @@ end
 # Extended Problem Construction (for Streaming)
 # =============================================================================
 
-function _make_extended_problem(prob::WeberProblem)
+function _make_extended_problem(prob::HamiltonianProblem)
     max_time = prob.tspan[1] + 1000 * prob.dt
-    return WeberProblem(
+    return HamiltonianProblem(
         prob.system,
         (prob.tspan[1], max_time),
         prob.q_initial,
@@ -929,7 +929,7 @@ end
 # =============================================================================
 
 """
-    animate_weber(prob::WeberProblem; kwargs...) -> screen
+    animate_weber(prob::HamiltonianProblem; kwargs...) -> screen
 
 Launch an interactive real-time animation of a Weber simulation.
 
@@ -955,7 +955,7 @@ WGLMakie recommended). Requires at least 2D (`prob.system.dims ≥ 2`).
 - A Makie screen handle; close the window to stop the simulation.
 """
 function WeberElectrodynamics.animate_weber(
-    prob::WeberProblem;
+    prob::HamiltonianProblem;
     buffer_size::Int = 2000,
     tail_length::Int = 200,
     compute_batch::Int = 1,
@@ -1015,9 +1015,9 @@ end
 # =============================================================================
 
 """
-    animate_weber(sol::WeberSolution; kwargs...) -> screen
+    animate_weber(sol::HamiltonianSolution; kwargs...) -> screen
 
-Replay a completed `WeberSolution` as an interactive animated dashboard.
+Replay a completed `HamiltonianSolution` as an interactive animated dashboard.
 
 Identical dashboard layout to the streaming form (single dominant trajectory
 panel, phase-space sidebar, live energy-error readout), but replays
@@ -1039,7 +1039,7 @@ pre-computed trajectory data. Requires at least 2D
 - A Makie screen handle; close the window to stop replay.
 """
 function WeberElectrodynamics.animate_weber(
-    sol::WeberSolution;
+    sol::HamiltonianSolution;
     buffer_size::Int = 2000,
     tail_length::Int = 200,
     compute_batch::Int = 1,

--- a/ext/WeberElectrodynamicsPlotsExt.jl
+++ b/ext/WeberElectrodynamicsPlotsExt.jl
@@ -955,8 +955,8 @@ Both solutions must have the same number of particles and dimensions.
 Solid lines = `sol1`, dashed lines = `sol2`.
 """
 function WeberElectrodynamics.plot_weber_vs_zollner(
-    sol1::WeberSolution,
-    sol2::WeberSolution;
+    sol1::HamiltonianSolution,
+    sol2::HamiltonianSolution;
     labels::Vector{String} = ["Weber", "Zöllner"],
 )::Plots.Plot
     n1 = sol1.prob.system.n_particles

--- a/src/WeberElectrodynamics.jl
+++ b/src/WeberElectrodynamics.jl
@@ -8,16 +8,16 @@ export @sprintf, norm, dot
 # =============================================================================
 # Weber System (n-body Hamiltonian)
 # =============================================================================
-include("weber_system.jl")
-export WeberSystem
+include("hamiltonian_system.jl")
+export HamiltonianSystem
 
 # =============================================================================
 # Core Types (Problem, Solution, Integrator)
 # =============================================================================
 include("types.jl")
-export WeberProblem
-export WeberSolution
-export WeberIntegrator
+export HamiltonianProblem
+export HamiltonianSolution
+export HamiltonianIntegrator
 export RegularizationOptions
 export RegularizationDiagnostics
 export ZollnerOptions
@@ -212,9 +212,9 @@ export plot_zollner_energy, plot_zollner_force_residual, plot_weber_vs_zollner, 
 Launch an interactive animated dashboard for a Weber simulation.
 
 Two modes:
-- `animate_weber(prob::WeberProblem; ...)` — **streaming**: runs the integrator
+- `animate_weber(prob::HamiltonianProblem; ...)` — **streaming**: runs the integrator
   live and displays data in real time. Requires a windowed backend (GLMakie or WGLMakie).
-- `animate_weber(sol::WeberSolution; ...)` — **replay**: replays a completed solution.
+- `animate_weber(sol::HamiltonianSolution; ...)` — **replay**: replays a completed solution.
 
 The dashboard shows particle trajectories, energy, momentum, and phase-space panels.
 Requires at least 2D (`dims ≥ 2`).

--- a/src/hamiltonian_system.jl
+++ b/src/hamiltonian_system.jl
@@ -2,12 +2,12 @@ using Symbolics
 using Latexify: latexify
 
 """
-    WeberSystem
+    HamiltonianSystem
 
 Symbolic and compiled representation of the n-body Weber Hamiltonian.
 
-Constructed once for a given `(n_particles, dims)` pair via `WeberSystem(n_particles, dims)`.
-The compiled equations of motion are reused across many `WeberProblem` instances
+Constructed once for a given `(n_particles, dims)` pair via `HamiltonianSystem(n_particles, dims)`.
+The compiled equations of motion are reused across many `HamiltonianProblem` instances
 with different physical parameters. Construction involves symbolic differentiation
 and code generation via Symbolics.jl; expect a few seconds for the first call.
 
@@ -26,7 +26,7 @@ and code generation via Symbolics.jl; expect a few seconds for the first call.
 - `hamiltonian_compiled(q, p, t, params)`: Compiled scalar Hamiltonian function.
 - `degrees_of_freedom::Int`: Total DOF = `n_particles × dims`.
 """
-struct WeberSystem{H,QD,PD,QF,PF,HF,PS}
+struct HamiltonianSystem{H,QD,PD,QF,PF,HF,PS}
     n_particles::Int
     dims::Int
 
@@ -135,23 +135,23 @@ function _build_weber_hamiltonian(
 end
 
 """
-    WeberSystem(n_particles::Int, dims::Int) -> WeberSystem
+    HamiltonianSystem(n_particles::Int, dims::Int) -> HamiltonianSystem
 
 Build and compile the symbolic Weber Hamiltonian for `n_particles` particles in
 `dims` dimensions.
 
 Uses Symbolics.jl to derive Hamilton's equations analytically, then compiles
 them to efficient in-place Julia functions via `build_function`. The resulting
-`WeberSystem` can be reused across multiple `WeberProblem` instances.
+`HamiltonianSystem` can be reused across multiple `HamiltonianProblem` instances.
 
 # Arguments
 - `n_particles`: Number of particles (≥ 1).
 - `dims`: Spatial dimension; must be 1, 2, or 3.
 
 # Returns
-- `WeberSystem` with compiled equations of motion ready for `WeberProblem`.
+- `HamiltonianSystem` with compiled equations of motion ready for `HamiltonianProblem`.
 """
-function WeberSystem(n_particles::Int, dims::Int)
+function HamiltonianSystem(n_particles::Int, dims::Int)
     @assert n_particles >= 1 "Must have at least 1 particle"
     @assert dims in (1, 2, 3) "Dimensions must be 1, 2, or 3, got $dims"
 
@@ -194,7 +194,7 @@ function WeberSystem(n_particles::Int, dims::Int)
 
     degrees_of_freedom = n_particles * dims
 
-    WeberSystem(
+    HamiltonianSystem(
         n_particles,
         dims,
         q_vars,
@@ -211,21 +211,21 @@ function WeberSystem(n_particles::Int, dims::Int)
     )
 end
 
-function Base.show(io::IO, sys::WeberSystem)
+function Base.show(io::IO, sys::HamiltonianSystem)
     print(
         io,
-        "WeberSystem($(sys.n_particles) particles, $(sys.dims)D, $(sys.degrees_of_freedom) DOF)",
+        "HamiltonianSystem($(sys.n_particles) particles, $(sys.dims)D, $(sys.degrees_of_freedom) DOF)",
     )
 end
 
-function Base.show(io::IO, ::MIME"text/plain", sys::WeberSystem)
-    println(io, "WeberSystem")
+function Base.show(io::IO, ::MIME"text/plain", sys::HamiltonianSystem)
+    println(io, "HamiltonianSystem")
     println(io, "  Particles: $(sys.n_particles)")
     println(io, "  Dimensions: $(sys.dims)")
     println(io, "  DOF: $(sys.degrees_of_freedom)")
     println(io, "  H = $(sys.hamiltonian_symbolic)")
 end
 
-function Base.show(io::IO, ::MIME"text/latex", sys::WeberSystem)
+function Base.show(io::IO, ::MIME"text/latex", sys::HamiltonianSystem)
     print(io, latexify(sys.hamiltonian_symbolic))
 end

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -99,7 +99,7 @@ end
     p::Vector{Float64},
     t::Float64,
     dt_step::Float64,
-    prob::WeberProblem,
+    prob::HamiltonianProblem,
     alg::SymmetricProjectionIntegrator,
     buffers::SymmetricProjectionBuffers,
 )
@@ -260,7 +260,7 @@ end
 end
 
 @inline function _update_diagnostics!(
-    integrator::WeberIntegrator,
+    integrator::HamiltonianIntegrator,
     mode::UInt8,
     substeps::Int,
     min_distance::Float64,
@@ -309,7 +309,7 @@ end
     return nothing
 end
 
-@inline function _store_state!(integrator::WeberIntegrator, dt_step::Float64)
+@inline function _store_state!(integrator::HamiltonianIntegrator, dt_step::Float64)
     integrator.step_count += 1
     integrator.t += dt_step
     if integrator.t > integrator.t_end
@@ -328,7 +328,7 @@ end
 
 @inline function _set_pair_params!(
     rb::RegularizationBuffers,
-    prob::WeberProblem,
+    prob::HamiltonianProblem,
     i::Int,
     j::Int,
 )
@@ -362,7 +362,7 @@ end
     q_state::Vector{Float64},
     p_state::Vector{Float64},
     t::Float64,
-    prob::WeberProblem,
+    prob::HamiltonianProblem,
 )
     system = prob.system
     system.dq_dt_compiled(rb.dq_full, q_state, p_state, t, prob.params)
@@ -381,7 +381,7 @@ end
     p::Vector{Float64},
     t::Float64,
     dt_half::Float64,
-    prob::WeberProblem,
+    prob::HamiltonianProblem,
     rb::RegularizationBuffers,
 )
     if dt_half <= 0
@@ -632,7 +632,7 @@ end
     p::Vector{Float64},
     t::Float64,
     dt_sub::Float64,
-    prob::WeberProblem,
+    prob::HamiltonianProblem,
     rb::RegularizationBuffers,
     i::Int,
     j::Int,
@@ -748,7 +748,7 @@ end
 end
 
 @inline function _step_unregularized!(
-    integrator::WeberIntegrator,
+    integrator::HamiltonianIntegrator,
     dt_step::Float64,
 )
     _projected_cartesian_step!(
@@ -775,7 +775,7 @@ end
 end
 
 @inline function _step_regularized_pair_adaptive!(
-    integrator::WeberIntegrator,
+    integrator::HamiltonianIntegrator,
     dt_step::Float64,
     min_distance::Float64,
 )
@@ -854,7 +854,7 @@ end
 end
 
 @inline function _step_regularized_pair_lifted_2d!(
-    integrator::WeberIntegrator,
+    integrator::HamiltonianIntegrator,
     dt_step::Float64,
     min_distance::Float64,
 )
@@ -920,7 +920,7 @@ end
 end
 
 @inline function _step_regularized_chain!(
-    integrator::WeberIntegrator,
+    integrator::HamiltonianIntegrator,
     dt_step::Float64,
     min_distance::Float64,
 )
@@ -985,7 +985,7 @@ end
 end
 
 @inline function _step_regularized_dispatch!(
-    integrator::WeberIntegrator,
+    integrator::HamiltonianIntegrator,
     dt_step::Float64,
 )
     prob = integrator.prob
@@ -1051,7 +1051,7 @@ end
 end
 
 """
-    init(prob::WeberProblem, alg::SymmetricProjectionIntegrator = SymmetricProjectionIntegrator()) -> WeberIntegrator
+    init(prob::HamiltonianProblem, alg::SymmetricProjectionIntegrator = SymmetricProjectionIntegrator()) -> HamiltonianIntegrator
 
 Initialise a step-by-step integrator without running any steps.
 
@@ -1060,10 +1060,10 @@ trajectory. Use the returned integrator with `step!` for fine-grained control,
 or pass it directly to `solve!`.
 
 # Returns
-- `WeberIntegrator` at `t = prob.tspan[1]` with `step_count = 0`.
+- `HamiltonianIntegrator` at `t = prob.tspan[1]` with `step_count = 0`.
 """
 function CommonSolve.init(
-    prob::WeberProblem,
+    prob::HamiltonianProblem,
     alg::SymmetricProjectionIntegrator = SymmetricProjectionIntegrator(),
 )
     degrees_of_freedom = prob.system.degrees_of_freedom
@@ -1089,7 +1089,7 @@ function CommonSolve.init(
         @warn "RegularizationOptions(backend=:lifted_pair) is currently supported only for 2D; falling back to :adaptive_cartesian for $(prob.system.dims)D"
     end
 
-    WeberIntegrator(
+    HamiltonianIntegrator(
         prob,
         alg,
         prob.tspan[1],
@@ -1127,7 +1127,7 @@ end
 end
 
 """
-    step!(integrator::WeberIntegrator) -> Bool
+    step!(integrator::HamiltonianIntegrator) -> Bool
 
 Advance the integrator by one macro time step `prob.dt`.
 
@@ -1138,7 +1138,7 @@ step is automatically shortened to land exactly on `prob.tspan[2]`.
 # Returns
 - `true` if more steps remain, `false` when integration is complete.
 """
-function CommonSolve.step!(integrator::WeberIntegrator)
+function CommonSolve.step!(integrator::HamiltonianIntegrator)
     max_steps = length(integrator.t_history) - 1
 
     if integrator.step_count >= max_steps || integrator.t >= integrator.t_end - eps(integrator.t_end)
@@ -1180,7 +1180,7 @@ function CommonSolve.step!(integrator::WeberIntegrator)
 end
 
 """
-    solve!(integrator::WeberIntegrator) -> WeberSolution
+    solve!(integrator::HamiltonianIntegrator) -> HamiltonianSolution
 
 Run the integrator to completion and return the full solution.
 
@@ -1188,9 +1188,9 @@ Repeatedly calls `step!` until `t ≥ t_end`. If the fixed-point projection
 fails to converge, `retcode` is set to `:Failure` rather than throwing.
 
 # Returns
-- `WeberSolution` containing the full time series and regularization diagnostics.
+- `HamiltonianSolution` containing the full time series and regularization diagnostics.
 """
-function CommonSolve.solve!(integrator::WeberIntegrator)
+function CommonSolve.solve!(integrator::HamiltonianIntegrator)
     retcode = :Success
     try
         while CommonSolve.step!(integrator)
@@ -1206,7 +1206,7 @@ function CommonSolve.solve!(integrator::WeberIntegrator)
     n = integrator.step_count + 1
     diagnostics = _clone_diagnostics(integrator.diagnostics, integrator.step_count)
 
-    WeberSolution(
+    HamiltonianSolution(
         integrator.t_history[1:n],
         integrator.q_history[1:n],
         integrator.p_history[1:n],
@@ -1217,17 +1217,17 @@ function CommonSolve.solve!(integrator::WeberIntegrator)
 end
 
 """
-    solve(prob::WeberProblem, alg::WeberAlgorithm = SymmetricProjectionIntegrator()) -> WeberSolution
+    solve(prob::HamiltonianProblem, alg::WeberAlgorithm = SymmetricProjectionIntegrator()) -> HamiltonianSolution
 
 Initialise and run the integrator in a single call.
 
 Convenience wrapper equivalent to `solve!(init(prob, alg))`.
 
 # Returns
-- `WeberSolution` with `retcode ∈ {:Success, :Failure}`.
+- `HamiltonianSolution` with `retcode ∈ {:Success, :Failure}`.
 """
 function CommonSolve.solve(
-    prob::WeberProblem,
+    prob::HamiltonianProblem,
     alg::WeberAlgorithm = SymmetricProjectionIntegrator(),
 )
     integrator = CommonSolve.init(prob, alg)

--- a/src/statistics/energy.jl
+++ b/src/statistics/energy.jl
@@ -226,7 +226,7 @@ end
 """
     compute_energy_timeseries(sol; stride=1) -> EnergyData
 
-Compute the full energy decomposition timeseries from a `WeberSolution`.
+Compute the full energy decomposition timeseries from a `HamiltonianSolution`.
 
 Evaluates kinetic energy, per-pair Weber potentials, and the compiled Hamiltonian
 at each selected timestep. The `hamiltonian_validation_error` field cross-checks
@@ -238,7 +238,7 @@ the manual decomposition against the Symbolics-compiled function.
 # Returns
 - `EnergyData` with all energy components and conservation statistics.
 """
-function compute_energy_timeseries(solution::WeberSolution; stride::Int = 1)::EnergyData
+function compute_energy_timeseries(solution::HamiltonianSolution; stride::Int = 1)::EnergyData
     if stride <= 0
         throw(ArgumentError("stride must be positive, got $stride"))
     end

--- a/src/statistics/forces.jl
+++ b/src/statistics/forces.jl
@@ -109,7 +109,7 @@ Both the vector form and the radial form of the Weber force are evaluated, toget
 with phase-space data (r, ṙ, θ, L).
 
 # Arguments
-- `sol::WeberSolution`: Completed simulation.
+- `sol::HamiltonianSolution`: Completed simulation.
 - `pair::Tuple{Int,Int}`: Particle pair indices (order does not matter; i ≠ j).
 - `n_particles::Int`, `dims::Int`: System geometry.
 - `masses`, `charges::Vector{Float64}`: Physical parameters.
@@ -122,7 +122,7 @@ with phase-space data (r, ṙ, θ, L).
 - `PairForceData` with force vectors, decompositions, statistics, and phase-space data.
 """
 function compute_pair_force_timeseries(
-    sol::WeberSolution,
+    sol::HamiltonianSolution,
     pair::Tuple{Int,Int},
     n_particles::Int,
     dims::Int,

--- a/src/statistics/momentum.jl
+++ b/src/statistics/momentum.jl
@@ -32,7 +32,7 @@ end
 """
     compute_momentum_timeseries(solution; stride=1) -> MomentumData
 
-Compute total linear and angular momentum timeseries from a `WeberSolution`.
+Compute total linear and angular momentum timeseries from a `HamiltonianSolution`.
 
 # Keywords
 - `stride=1`: Downsample factor; every `stride`-th timestep is included.
@@ -40,7 +40,7 @@ Compute total linear and angular momentum timeseries from a `WeberSolution`.
 # Returns
 - `MomentumData` with linear and angular momentum at each selected timestep.
 """
-function compute_momentum_timeseries(solution::WeberSolution; stride::Int=1)::MomentumData
+function compute_momentum_timeseries(solution::HamiltonianSolution; stride::Int=1)::MomentumData
     if stride <= 0
         throw(ArgumentError("stride must be positive, got $stride"))
     end

--- a/src/statistics/trajectories.jl
+++ b/src/statistics/trajectories.jl
@@ -1,7 +1,7 @@
 """
     TrajectoryData
 
-Per-particle position trajectories extracted from a `WeberSolution`.
+Per-particle position trajectories extracted from a `HamiltonianSolution`.
 
 # Fields
 - `trajectories::Vector{Matrix{Float64}}`: One `(n_points, dims)` matrix per
@@ -24,10 +24,10 @@ end
 """
     compute_trajectory_data(sol, n_particles, dims; stride=1) -> TrajectoryData
 
-Extract per-particle position trajectories from a `WeberSolution`.
+Extract per-particle position trajectories from a `HamiltonianSolution`.
 
 # Arguments
-- `sol::WeberSolution`: Completed simulation result.
+- `sol::HamiltonianSolution`: Completed simulation result.
 - `n_particles::Int`: Number of particles encoded in `sol`.
 - `dims::Int`: Spatial dimension (must match `sol.prob.system.dims`).
 
@@ -38,7 +38,7 @@ Extract per-particle position trajectories from a `WeberSolution`.
 - `TrajectoryData` with one `(n_points, dims)` trajectory matrix per particle.
 """
 function compute_trajectory_data(
-    sol::WeberSolution,
+    sol::HamiltonianSolution,
     n_particles::Int,
     dims::Int;
     stride::Int = 1,

--- a/src/types.jl
+++ b/src/types.jl
@@ -199,7 +199,7 @@ end
 
 Diagnostics collected during a `solve!` call describing regularization usage.
 
-Returned as `WeberSolution.regularization`. All step counts refer to macro-steps
+Returned as `HamiltonianSolution.regularization`. All step counts refer to macro-steps
 of the outer `SymmetricProjectionIntegrator`.
 
 # Fields
@@ -424,15 +424,15 @@ mutable struct RegularizationBuffers
 end
 
 """
-    WeberProblem(system, tspan, q_initial, p_initial; kwargs...)
+    HamiltonianProblem(system, tspan, q_initial, p_initial; kwargs...)
 
 Fully specified n-body Weber electrodynamics problem ready for integration.
 
-Packages the compiled `WeberSystem`, initial conditions, physical parameters,
+Packages the compiled `HamiltonianSystem`, initial conditions, physical parameters,
 and solver/regularization options into a single immutable structure.
 
 # Arguments
-- `system::WeberSystem`: Pre-built symbolic + compiled Hamiltonian system.
+- `system::HamiltonianSystem`: Pre-built symbolic + compiled Hamiltonian system.
 - `tspan::Tuple{Real,Real}`: Integration interval `(t_start, t_end)`.
 - `q_initial::AbstractVector`: Flattened initial positions, length = `n_particles × dims`.
 - `p_initial::AbstractVector`: Flattened initial momenta, length = `n_particles × dims`.
@@ -450,7 +450,7 @@ and solver/regularization options into a single immutable structure.
   See `ZollnerOptions` for all available fields.
 
 # Fields
-- `system::WeberSystem`: Compiled Hamiltonian system.
+- `system::HamiltonianSystem`: Compiled Hamiltonian system.
 - `tspan::Tuple{Float64,Float64}`: Integration interval.
 - `q_initial`, `p_initial::Vector{Float64}`: Initial phase-space point.
 - `masses`, `charges::Vector{Float64}`: Physical parameters.
@@ -463,8 +463,8 @@ and solver/regularization options into a single immutable structure.
 - `regularization::RegularizationOptions`: Regularization configuration.
 - `zollner::ZollnerOptions`: Zöllner extension configuration.
 """
-struct WeberProblem
-    system::WeberSystem
+struct HamiltonianProblem
+    system::HamiltonianSystem
     tspan::Tuple{Float64,Float64}
     q_initial::Vector{Float64}
     p_initial::Vector{Float64}
@@ -479,8 +479,8 @@ struct WeberProblem
     regularization::RegularizationOptions
     zollner::ZollnerOptions
 
-    function WeberProblem(
-        system::WeberSystem,
+    function HamiltonianProblem(
+        system::HamiltonianSystem,
         tspan::Tuple{Real,Real},
         q_initial::AbstractVector,
         p_initial::AbstractVector;
@@ -533,7 +533,7 @@ struct WeberProblem
 end
 
 """
-    WeberSolution
+    HamiltonianSolution
 
 Result returned by `solve` or `solve!`.
 
@@ -544,36 +544,36 @@ and `length(sol)`. Each index returns a `(t, q, p)` tuple.
 - `t::Vector{Float64}`: Time points.
 - `q::Vector{Vector{Float64}}`: Flattened position snapshots, one per time point.
 - `p::Vector{Vector{Float64}}`: Flattened momentum snapshots, one per time point.
-- `prob::WeberProblem`: The originating problem definition.
+- `prob::HamiltonianProblem`: The originating problem definition.
 - `retcode::Symbol`: `:Success` on normal completion, `:Failure` if the
   projection fixed-point failed to converge.
 - `regularization::RegularizationDiagnostics`: Regularization usage statistics.
 """
-struct WeberSolution
+struct HamiltonianSolution
     t::Vector{Float64}
     q::Vector{Vector{Float64}}
     p::Vector{Vector{Float64}}
-    prob::WeberProblem
+    prob::HamiltonianProblem
     retcode::Symbol
     regularization::RegularizationDiagnostics
 end
 
-Base.length(sol::WeberSolution) = length(sol.t)
-Base.getindex(sol::WeberSolution, i::Int) = (sol.t[i], sol.q[i], sol.p[i])
-Base.firstindex(sol::WeberSolution) = 1
-Base.lastindex(sol::WeberSolution) = length(sol)
+Base.length(sol::HamiltonianSolution) = length(sol.t)
+Base.getindex(sol::HamiltonianSolution, i::Int) = (sol.t[i], sol.q[i], sol.p[i])
+Base.firstindex(sol::HamiltonianSolution) = 1
+Base.lastindex(sol::HamiltonianSolution) = length(sol)
 
-function Base.iterate(sol::WeberSolution, state = 1)
+function Base.iterate(sol::HamiltonianSolution, state = 1)
     state > length(sol) && return nothing
     return (sol[state], state + 1)
 end
 
-function Base.show(io::IO, sol::WeberSolution)
-    print(io, "WeberSolution with $(length(sol)) timesteps (retcode: $(sol.retcode))")
+function Base.show(io::IO, sol::HamiltonianSolution)
+    print(io, "HamiltonianSolution with $(length(sol)) timesteps (retcode: $(sol.retcode))")
 end
 
-function Base.show(io::IO, ::MIME"text/plain", sol::WeberSolution)
-    println(io, "WeberSolution")
+function Base.show(io::IO, ::MIME"text/plain", sol::HamiltonianSolution)
+    println(io, "HamiltonianSolution")
     println(io, "  retcode: $(sol.retcode)")
     println(io, "  t: $(sol.t[1]) → $(sol.t[end]) ($(length(sol)) points)")
     println(io, "  DOF: $(length(sol.q[1]))")
@@ -636,7 +636,7 @@ mutable struct SymmetricProjectionBuffers
     diff_buffer::Vector{Float64}
     regularization_buffers::RegularizationBuffers
 
-    function SymmetricProjectionBuffers(prob::WeberProblem)
+    function SymmetricProjectionBuffers(prob::HamiltonianProblem)
         d = prob.system.degrees_of_freedom
         n_particles = prob.system.n_particles
         dims = prob.system.dims
@@ -693,7 +693,7 @@ mutable struct SymmetricProjectionBuffers
 end
 
 """
-    WeberIntegrator
+    HamiltonianIntegrator
 
 Mutable step-by-step integrator returned by `init`.
 
@@ -702,7 +702,7 @@ run to completion. The current state is accessible via `integrator.q`,
 `integrator.p`, and `integrator.t`.
 
 # Fields
-- `prob::WeberProblem`: Problem definition.
+- `prob::HamiltonianProblem`: Problem definition.
 - `alg::SymmetricProjectionIntegrator`: Algorithm parameters.
 - `t::Float64`: Current time.
 - `t_end::Float64`: Final time (`prob.tspan[2]`).
@@ -715,8 +715,8 @@ run to completion. The current state is accessible via `integrator.q`,
 - `q_history::Vector{Vector{Float64}}`: Pre-allocated position history.
 - `p_history::Vector{Vector{Float64}}`: Pre-allocated momentum history.
 """
-mutable struct WeberIntegrator
-    prob::WeberProblem
+mutable struct HamiltonianIntegrator
+    prob::HamiltonianProblem
     alg::SymmetricProjectionIntegrator
     t::Float64
     t_end::Float64
@@ -730,6 +730,6 @@ mutable struct WeberIntegrator
     p_history::Vector{Vector{Float64}}
 end
 
-function Base.show(io::IO, int::WeberIntegrator)
-    print(io, "WeberIntegrator at t=$(int.t) (step $(int.step_count))")
+function Base.show(io::IO, int::HamiltonianIntegrator)
+    print(io, "HamiltonianIntegrator at t=$(int.t) (step $(int.step_count))")
 end

--- a/test/regression/README.md
+++ b/test/regression/README.md
@@ -49,7 +49,7 @@ julia test/regression/validate.jl              # standalone
 
 `validate.jl` reads only the fixture setup dict and calls the current public
 API in `rebuild_problem`. When the API shape changes (e.g. Phase 1 of the
-refactor renames `WeberProblem` → `HamiltonianProblem`), update
+refactor renames `HamiltonianProblem` → `HamiltonianProblem`), update
 `rebuild_problem` to use the new constructors while keeping the fixtures
 themselves untouched. If the refactor genuinely changes numerical behaviour,
 document the reason and regenerate the fixtures in the same PR.

--- a/test/regression/capture.jl
+++ b/test/regression/capture.jl
@@ -131,8 +131,8 @@ function fixture_twobody_ellipse()
     tspan = (0.0, 2.0)
     dt = 5e-4
 
-    system = WeberSystem(2, 2)
-    prob = WeberProblem(
+    system = HamiltonianSystem(2, 2)
+    prob = HamiltonianProblem(
         system, tspan, q_initial, p_initial;
         masses = [m1, m2], charges = [q1, q2], c = c, dt = dt,
     )
@@ -144,7 +144,7 @@ end
 function fixture_threebody_mixed()
     # 3-body mixed-charge, unregularized. Starts from rest; well-separated so no
     # close encounters trigger. Weber velocity corrections are small.
-    system = WeberSystem(3, 2)
+    system = HamiltonianSystem(3, 2)
     q_initial = [1.0, 0.0, -0.5, 0.0, 0.2, 1.5]
     p_initial = zeros(6)
     masses = [1.0, 1.0, 0.5]
@@ -152,7 +152,7 @@ function fixture_threebody_mixed()
     c = 10.0
     tspan = (0.0, 0.5)
     dt = 5e-4
-    prob = WeberProblem(
+    prob = HamiltonianProblem(
         system, tspan, q_initial, p_initial;
         masses = masses, charges = charges, c = c, dt = dt,
     )
@@ -190,8 +190,8 @@ function fixture_close_approach_lifted()
         warn_on_fallback = false,
     )
 
-    system = WeberSystem(2, 2)
-    prob = WeberProblem(
+    system = HamiltonianSystem(2, 2)
+    prob = HamiltonianProblem(
         system, tspan, q_initial, p_initial;
         masses = [m1, m2], charges = [q1, q2], c = c, dt = dt,
         regularization = reg,
@@ -231,8 +231,8 @@ function fixture_zollner_offmatch()
     )
     zol = ZollnerOptions(enabled = true, a = 0.05)
 
-    system = WeberSystem(2, 2)
-    prob = WeberProblem(
+    system = HamiltonianSystem(2, 2)
+    prob = HamiltonianProblem(
         system, tspan, q_initial, p_initial;
         masses = [m1, m2], charges = [q1, q2], c = c, dt = dt,
         regularization = reg,
@@ -247,7 +247,7 @@ end
 # Write JLD2 fixture file
 # ---------------------------------------------------------------------------
 
-function save_fixture(prob::WeberProblem, sol::WeberSolution, name::String, desc::String)
+function save_fixture(prob::HamiltonianProblem, sol::HamiltonianSolution, name::String, desc::String)
     setup = Dict{String,Any}(
         "n_particles" => prob.system.n_particles,
         "dims" => prob.system.dims,

--- a/test/regression/validate.jl
+++ b/test/regression/validate.jl
@@ -60,7 +60,7 @@ function _rebuild_zollner_options(d::Dict{String,Any})
     ZollnerOptions(enabled = d["enabled"], a = d["a"])
 end
 
-# Rebuild the WeberProblem corresponding to a fixture.
+# Rebuild the HamiltonianProblem corresponding to a fixture.
 #
 # This function is the single point that must be updated each time the public
 # problem-building API changes (e.g. Phase 1 of the refactor will rewrite it
@@ -68,14 +68,14 @@ end
 function rebuild_problem(setup::Dict{String,Any})
     n_particles = setup["n_particles"]::Int
     dims = setup["dims"]::Int
-    system = WeberSystem(n_particles, dims)
+    system = HamiltonianSystem(n_particles, dims)
 
     reg = _rebuild_reg_options(setup["regularization"])
     zol = _rebuild_zollner_options(setup["zollner"])
 
     tspan = Tuple(setup["tspan"]::Vector{Float64})
 
-    return WeberProblem(
+    return HamiltonianProblem(
         system,
         tspan,
         setup["q_initial"]::Vector{Float64},

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,7 @@ using Symbolics
 @testset "WeberElectrodynamics.jl" begin
     include("test_utils.jl")
     include("test_types.jl")
-    include("test_weber_system.jl")
+    include("test_hamiltonian_system.jl")
     include("test_solve.jl")
     include("test_statistics.jl")
     include("test_integration.jl")

--- a/test/test_hamiltonian_system.jl
+++ b/test/test_hamiltonian_system.jl
@@ -3,7 +3,7 @@ using WeberElectrodynamics: _pair_index
 @testset "Weber System" begin
     @testset "Weber Hamiltonian structure" begin
         # 2-body 2D Weber system
-        system = WeberSystem(2, 2)
+        system = HamiltonianSystem(2, 2)
 
         @test system.degrees_of_freedom == 4
         @test length(system.dq_dt_symbolic) == 4
@@ -20,7 +20,7 @@ using WeberElectrodynamics: _pair_index
         q1, q2 = 1.0, -1.0
         c = 1000.0  # Large c to make Weber ≈ Coulomb
 
-        system = WeberSystem(2, 2)
+        system = HamiltonianSystem(2, 2)
         # params = [m1, m2, q1, q2, c, κ₁₂]; κ=1 (Zöllner disabled)
         params = [m1, m2, q1, q2, c, 1.0]
 
@@ -51,7 +51,7 @@ using WeberElectrodynamics: _pair_index
 
     @testset "Different dimensions" begin
         # 1D system
-        sys1d = WeberSystem(2, 1)
+        sys1d = HamiltonianSystem(2, 1)
         @test sys1d.degrees_of_freedom == 2
         @test length(sys1d.dq_dt_symbolic) == 2
 
@@ -64,18 +64,18 @@ using WeberElectrodynamics: _pair_index
         @test all(isfinite.(out1))
 
         # 2D system
-        sys2d = WeberSystem(2, 2)
+        sys2d = HamiltonianSystem(2, 2)
         @test sys2d.degrees_of_freedom == 4
 
         # 3D system
-        sys3d = WeberSystem(2, 3)
+        sys3d = HamiltonianSystem(2, 3)
         @test sys3d.degrees_of_freedom == 6
         @test length(sys3d.dq_dt_symbolic) == 6
     end
 
     @testset "Multiple particles" begin
         # 3-body system
-        sys3body = WeberSystem(3, 2)
+        sys3body = HamiltonianSystem(3, 2)
         @test sys3body.degrees_of_freedom == 6
         @test sys3body.n_particles == 3
 
@@ -95,7 +95,7 @@ using WeberElectrodynamics: _pair_index
 
     @testset "Single particle system" begin
         # Single particle has no interactions, just kinetic energy
-        sys1 = WeberSystem(1, 2)
+        sys1 = HamiltonianSystem(1, 2)
         @test sys1.degrees_of_freedom == 2
 
         params1 = [2.0, 1.0, 1.0]  # m1, q1, c
@@ -122,7 +122,7 @@ using WeberElectrodynamics: _pair_index
         q1, q2 = 0.3, -0.3
         c = 4.0
 
-        system = WeberSystem(2, 2)
+        system = HamiltonianSystem(2, 2)
 
         # Test state
         q = [1.0, 0.0, -1.0, 0.0]
@@ -139,7 +139,7 @@ using WeberElectrodynamics: _pair_index
     end
 
     @testset "Symbolic parameters in Hamiltonian" begin
-        system = WeberSystem(2, 2)
+        system = HamiltonianSystem(2, 2)
         H_str = string(system.hamiltonian_symbolic)
 
         # Hamiltonian should contain symbolic parameters, not numerical values

--- a/test/test_integration.jl
+++ b/test/test_integration.jl
@@ -6,7 +6,7 @@
         q2_charge = -sqrt(0.1)  # q1*q2 = -0.1 (attractive)
         c = 4.0
 
-        system = WeberSystem(2, 2)
+        system = HamiltonianSystem(2, 2)
 
         r0 = 2.0
         M = m1 + m2
@@ -15,7 +15,7 @@
         q0 = [-m2 / M * r0, 0.0, m1 / M * r0, 0.0]
         p0 = [0.0, m1 * (-m2 / M * v_circ * 0.9), 0.0, m2 * (m1 / M * v_circ * 0.9)]
 
-        prob = WeberProblem(system, (0.0, 1.0), q0, p0;
+        prob = HamiltonianProblem(system, (0.0, 1.0), q0, p0;
             masses = [m1, m2], charges = [q1_charge, q2_charge], c = c, dt = 0.001)
 
         # Solve
@@ -83,7 +83,7 @@
         c = 4.0
 
         for scale in [0.5, 1.0, 2.0]
-            system = WeberSystem(2, 2)
+            system = HamiltonianSystem(2, 2)
             r0 = 2.0 * scale
             M = m1 + m2
             k = q1_charge * q2_charge
@@ -91,7 +91,7 @@
             q0 = [-m2 / M * r0, 0.0, m1 / M * r0, 0.0]
             p0 = [0.0, m1 * (-m2 / M * v_circ * 0.9), 0.0, m2 * (m1 / M * v_circ * 0.9)]
 
-            prob = WeberProblem(system, (0.0, 1.0), q0, p0;
+            prob = HamiltonianProblem(system, (0.0, 1.0), q0, p0;
                 masses = [m1, m2], charges = [q1_charge, q2_charge], c = c, dt = 0.001)
             sol = solve(prob)
             @test sol.retcode == :Success

--- a/test/test_physics.jl
+++ b/test/test_physics.jl
@@ -213,7 +213,7 @@
         q1, q2 = 1.0, -1.0
 
         # Single system, different params
-        sys = WeberSystem(2, 2)
+        sys = HamiltonianSystem(2, 2)
 
         # Test at specific point
         q = [1.0, 0.0, -1.0, 0.0]

--- a/test/test_regularization.jl
+++ b/test/test_regularization.jl
@@ -36,8 +36,8 @@
             charges = [q1, q2]
         end
 
-        system = WeberSystem(2, dims)
-        return WeberProblem(
+        system = HamiltonianSystem(2, dims)
+        return HamiltonianProblem(
             system,
             (0.0, t_end),
             q0,
@@ -57,15 +57,15 @@
         )
     end
 
-    state_error(sol_a::WeberSolution, sol_b::WeberSolution) =
+    state_error(sol_a::HamiltonianSolution, sol_b::HamiltonianSolution) =
         norm(sol_a.q[end] - sol_b.q[end]) + norm(sol_a.p[end] - sol_b.p[end])
 
     @testset "API and fallback" begin
-        sys2 = WeberSystem(2, 2)
+        sys2 = HamiltonianSystem(2, 2)
         q0_2d = [-1.0, 0.0, 1.0, 0.0]
         p0_2d = [0.0, -0.05, 0.0, 0.05]
 
-        prob_valid = WeberProblem(
+        prob_valid = HamiltonianProblem(
             sys2,
             (0.0, 0.1),
             q0_2d,
@@ -82,7 +82,7 @@
         )
         @test prob_valid.regularization.backend == WeberElectrodynamics.REG_BACKEND_ADAPTIVE
 
-        @test_throws AssertionError WeberProblem(
+        @test_throws AssertionError HamiltonianProblem(
             sys2,
             (0.0, 0.1),
             q0_2d,
@@ -97,11 +97,11 @@
             ),
         )
 
-        sys1 = WeberSystem(2, 1)
+        sys1 = HamiltonianSystem(2, 1)
         q0_1d = [-0.08, 0.08]
         p0_1d = [0.0, 0.0]
 
-        prob_fb = WeberProblem(
+        prob_fb = HamiltonianProblem(
             sys1,
             (0.0, 0.01),
             q0_1d,
@@ -128,7 +128,7 @@
         @test int_fb.diagnostics.lifted_pair_steps == 0
         @test int_fb.diagnostics.backend_fallback_steps == 1
 
-        prob_warn = WeberProblem(
+        prob_warn = HamiltonianProblem(
             sys1,
             (0.0, 0.01),
             q0_1d,
@@ -149,13 +149,13 @@
     end
 
     @testset "3D lifted pair fallback to adaptive_cartesian" begin
-        sys3 = WeberSystem(2, 3)
+        sys3 = HamiltonianSystem(2, 3)
         # Start within r_on (separation 0.16 < r_on 0.2) so regularization fires
         # on the first step and backend_fallback_steps is immediately exercised.
         q0_3d = [-0.08, 0.0, 0.0, 0.08, 0.0, 0.0]
         p0_3d = [0.0, -0.05, 0.0, 0.0, 0.05, 0.0]
 
-        prob_3d = WeberProblem(
+        prob_3d = HamiltonianProblem(
             sys3,
             (0.0, 0.01),
             q0_3d,
@@ -181,7 +181,7 @@
         @test int_3d.diagnostics.backend_fallback_steps == 1
         @test int_3d.diagnostics.lifted_pair_steps == 0
 
-        @test_logs (:warn, r"falling back to :adaptive_cartesian") init(WeberProblem(
+        @test_logs (:warn, r"falling back to :adaptive_cartesian") init(HamiltonianProblem(
             sys3,
             (0.0, 0.01),
             q0_3d,
@@ -309,10 +309,10 @@
         @test rb.active_count > 2
         @test mode == WeberElectrodynamics.REG_MODE_NONE
 
-        sys = WeberSystem(3, 2)
+        sys = HamiltonianSystem(3, 2)
         q0 = [-0.09, 0.0, 0.09, 0.0, 0.2, 0.0]
         p0 = [0.0, 0.02, 0.0, 0.0, 0.0, -0.02]
-        prob = WeberProblem(
+        prob = HamiltonianProblem(
             sys,
             (0.0, 0.1),
             q0,
@@ -412,11 +412,11 @@
         rho = q1 * q2 / (mu * c^2)
         T_est = (2π / c) * rho
 
-        sys = WeberSystem(2, 2)
+        sys = HamiltonianSystem(2, 2)
         q_init = [r0 / 2, 0.0, -r0 / 2, 0.0]
         p_init = [0.0, 0.0, 0.0, 0.0]
 
-        prob = WeberProblem(
+        prob = HamiltonianProblem(
             sys,
             (0.0, 10 * T_est),
             q_init,
@@ -463,11 +463,11 @@
         rho = q1 * q2 / (mu * c^2)
         T_est = (2π / c) * rho
 
-        sys = WeberSystem(2, 2)
+        sys = HamiltonianSystem(2, 2)
         q_init = [r0 / 2, 0.0, -r0 / 2, 0.0]
         p_init = [0.0, 0.0, 0.0, 0.0]
 
-        prob = WeberProblem(
+        prob = HamiltonianProblem(
             sys,
             (0.0, 5 * T_est),
             q_init,
@@ -498,11 +498,11 @@
     end
 
     @testset "Chain mode correctness" begin
-        sys = WeberSystem(3, 2)
+        sys = HamiltonianSystem(3, 2)
         q0 = [-0.12, 0.0, 0.0, 0.0, 0.12, 0.0]
         p0 = [0.0, 0.02, 0.0, 0.0, 0.0, -0.02]
 
-        prob = WeberProblem(
+        prob = HamiltonianProblem(
             sys,
             (0.0, 0.2),
             q0,
@@ -529,7 +529,7 @@
     end
 
     @testset "Backward mode parity" begin
-        sys = WeberSystem(2, 2)
+        sys = HamiltonianSystem(2, 2)
         q0 = [-1.0, 0.0, 1.0, 0.0]
         p0 = [0.0, -0.05, 0.0, 0.05]
 
@@ -540,7 +540,7 @@
             dt = 0.001,
         )
 
-        prob_off = WeberProblem(
+        prob_off = HamiltonianProblem(
             sys,
             (0.0, 0.2),
             q0,
@@ -548,7 +548,7 @@
             kwargs...,
             regularization = RegularizationOptions(enabled = false),
         )
-        prob_on = WeberProblem(
+        prob_on = HamiltonianProblem(
             sys,
             (0.0, 0.2),
             q0,
@@ -576,10 +576,10 @@
     end
 
     @testset "Single-particle regularization safety" begin
-        sys = WeberSystem(1, 2)
+        sys = HamiltonianSystem(1, 2)
         q0 = [0.0, 0.0]
         p0 = [0.0, 0.0]
-        prob = WeberProblem(
+        prob = HamiltonianProblem(
             sys,
             (0.0, 0.1),
             q0,
@@ -625,11 +625,11 @@
     end
 
     @testset "Allocation checks" begin
-        sys = WeberSystem(2, 2)
+        sys = HamiltonianSystem(2, 2)
 
         q0 = [-1.0, 0.0, 1.0, 0.0]
         p0 = [0.0, -0.05, 0.0, 0.05]
-        prob_unreg = WeberProblem(
+        prob_unreg = HamiltonianProblem(
             sys,
             (0.0, 0.02),
             q0,
@@ -647,7 +647,7 @@
 
         q1 = [-0.08, 0.01, 0.08, -0.01]
         p1 = [0.0, -0.02, 0.0, 0.02]
-        prob_lifted = WeberProblem(
+        prob_lifted = HamiltonianProblem(
             sys,
             (0.0, 0.02),
             q1,

--- a/test/test_solve.jl
+++ b/test/test_solve.jl
@@ -142,11 +142,11 @@
     end
 
     @testset "Custom tolerance" begin
-        system = WeberSystem(2, 2)
+        system = HamiltonianSystem(2, 2)
         q0 = [1.0, 0.0, -1.0, 0.0]
         p0 = [0.0, 0.05, 0.0, -0.05]
 
-        prob_tight = WeberProblem(
+        prob_tight = HamiltonianProblem(
             system,
             (0.0, 0.1),
             q0,

--- a/test/test_statistics.jl
+++ b/test/test_statistics.jl
@@ -61,8 +61,8 @@ using WeberElectrodynamics: compute_total_kinetic_energy, compute_pair_weber_com
 
         @testset "1D system" begin
             # Create a 1D 2-body system for this test
-            sys1d = WeberSystem(2, 1)
-            prob1d = WeberProblem(
+            sys1d = HamiltonianSystem(2, 1)
+            prob1d = HamiltonianProblem(
                 sys1d,
                 (0.0, 0.5),
                 [1.0, -1.0],
@@ -123,7 +123,7 @@ using WeberElectrodynamics: compute_total_kinetic_energy, compute_pair_weber_com
         @testset "Hamiltonian validation" begin
             energy = compute_energy_timeseries(sol_weber)
 
-            # Our computed energy should match WeberSystem's compiled Hamiltonian
+            # Our computed energy should match HamiltonianSystem's compiled Hamiltonian
             @test all(energy.hamiltonian_validation_error .< 1e-12)
         end
 
@@ -155,8 +155,8 @@ using WeberElectrodynamics: compute_total_kinetic_energy, compute_pair_weber_com
 
         @testset "3-body system" begin
             # Create a 3-body system to test n_pairs = 3
-            sys3 = WeberSystem(3, 2)
-            prob3 = WeberProblem(
+            sys3 = HamiltonianSystem(3, 2)
+            prob3 = HamiltonianProblem(
                 sys3,
                 (0.0, 0.1),
                 [1.0, 0.0, -0.5, 0.866, -0.5, -0.866],  # Triangle
@@ -388,8 +388,8 @@ using WeberElectrodynamics: compute_total_kinetic_energy, compute_pair_weber_com
         end
 
         @testset "2D angular momentum magnitude is absolute value" begin
-            sys2d = WeberSystem(2, 2)
-            prob2d = WeberProblem(
+            sys2d = HamiltonianSystem(2, 2)
+            prob2d = HamiltonianProblem(
                 sys2d,
                 (0.0, 0.01),
                 [1.0, 0.0, -1.0, 0.0],
@@ -439,8 +439,8 @@ using WeberElectrodynamics: compute_total_kinetic_energy, compute_pair_weber_com
 
         @testset "1D system (no angular momentum)" begin
             # Create a 1D 2-body system
-            sys1d = WeberSystem(2, 1)
-            prob1d = WeberProblem(
+            sys1d = HamiltonianSystem(2, 1)
+            prob1d = HamiltonianProblem(
                 sys1d,
                 (0.0, 0.5),
                 [1.0, -1.0],
@@ -460,8 +460,8 @@ using WeberElectrodynamics: compute_total_kinetic_energy, compute_pair_weber_com
 
         @testset "3D system" begin
             # Create a 3D 2-body system
-            sys3d = WeberSystem(2, 3)
-            prob3d = WeberProblem(
+            sys3d = HamiltonianSystem(2, 3)
+            prob3d = HamiltonianProblem(
                 sys3d,
                 (0.0, 0.5),
                 [1.0, 0.0, 0.0, -1.0, 0.0, 0.0],

--- a/test/test_types.jl
+++ b/test/test_types.jl
@@ -17,11 +17,11 @@
         @test_throws AssertionError SymmetricProjectionIntegrator(relaxation = 1.5)
     end
 
-    @testset "WeberSystem" begin
+    @testset "HamiltonianSystem" begin
         # Basic construction (now purely symbolic)
-        system = WeberSystem(2, 2)
+        system = HamiltonianSystem(2, 2)
 
-        @test system isa WeberSystem
+        @test system isa HamiltonianSystem
         @test system.n_particles == 2
         @test system.dims == 2
         @test system.degrees_of_freedom == 4
@@ -41,37 +41,37 @@
         @test length(system.p_symbols) == 4  # px1, py1, px2, py2
     end
 
-    @testset "WeberSystem validation" begin
+    @testset "HamiltonianSystem validation" begin
         # Valid cases
-        @test WeberSystem(1, 1) isa WeberSystem
-        @test WeberSystem(3, 3) isa WeberSystem
+        @test HamiltonianSystem(1, 1) isa HamiltonianSystem
+        @test HamiltonianSystem(3, 3) isa HamiltonianSystem
 
         # Invalid: dims must be 1, 2, or 3
-        @test_throws AssertionError WeberSystem(2, 0)
-        @test_throws AssertionError WeberSystem(2, 4)
+        @test_throws AssertionError HamiltonianSystem(2, 0)
+        @test_throws AssertionError HamiltonianSystem(2, 4)
     end
 
-    @testset "WeberSystem different configurations" begin
+    @testset "HamiltonianSystem different configurations" begin
         # 1D, 1 particle (minimal)
-        sys1 = WeberSystem(1, 1)
+        sys1 = HamiltonianSystem(1, 1)
         @test sys1.degrees_of_freedom == 1
 
         # 3D, 3 particles
-        sys2 = WeberSystem(3, 3)
+        sys2 = HamiltonianSystem(3, 3)
         @test sys2.degrees_of_freedom == 9
         @test length(sys2.dq_dt_symbolic) == 9
         @test length(sys2.dp_dt_symbolic) == 9
 
         # 2D, 2 particles (common case)
-        sys3 = WeberSystem(2, 2)
+        sys3 = HamiltonianSystem(2, 2)
         @test sys3.degrees_of_freedom == 4
     end
 
-    @testset "WeberProblem" begin
-        system = WeberSystem(2, 2)
+    @testset "HamiltonianProblem" begin
+        system = HamiltonianSystem(2, 2)
 
         # Valid construction
-        prob = WeberProblem(
+        prob = HamiltonianProblem(
             system,
             (0.0, 1.0),
             [1.0, 0.0, -1.0, 0.0],
@@ -101,7 +101,7 @@
         @test prob.regularization.max_substeps == 512
 
         # Custom convergence_tolerance and maximum_iterations
-        prob2 = WeberProblem(
+        prob2 = HamiltonianProblem(
             system,
             (0.0, 1.0),
             [1.0, 0.0, -1.0, 0.0],
@@ -127,7 +127,7 @@
         @test prob2.regularization.max_substeps == 64
 
         # Validation errors
-        @test_throws AssertionError WeberProblem(
+        @test_throws AssertionError HamiltonianProblem(
             system,
             (1.0, 0.0),
             [1.0, 0.0, -1.0, 0.0],
@@ -137,7 +137,7 @@
             c = 4.0,
             dt = 0.01,
         )  # tspan reversed
-        @test_throws AssertionError WeberProblem(
+        @test_throws AssertionError HamiltonianProblem(
             system,
             (0.0, 1.0),
             [1.0, 0.0, -1.0, 0.0],
@@ -147,7 +147,7 @@
             c = 4.0,
             dt = -0.01,
         )  # negative dt
-        @test_throws AssertionError WeberProblem(
+        @test_throws AssertionError HamiltonianProblem(
             system,
             (0.0, 1.0),
             [1.0, 2.0],
@@ -157,7 +157,7 @@
             c = 4.0,
             dt = 0.01,
         )  # q length mismatch
-        @test_throws AssertionError WeberProblem(
+        @test_throws AssertionError HamiltonianProblem(
             system,
             (0.0, 1.0),
             [1.0, 0.0, -1.0, 0.0],
@@ -167,7 +167,7 @@
             c = 4.0,
             dt = 0.01,
         )  # p length mismatch
-        @test_throws AssertionError WeberProblem(
+        @test_throws AssertionError HamiltonianProblem(
             system,
             (0.0, 1.0),
             [1.0, 0.0, -1.0, 0.0],
@@ -177,7 +177,7 @@
             c = 4.0,
             dt = 0.01,
         )
-        @test_throws AssertionError WeberProblem(
+        @test_throws AssertionError HamiltonianProblem(
             system,
             (0.0, 1.0),
             [1.0, 0.0, -1.0, 0.0],
@@ -187,7 +187,7 @@
             c = 4.0,
             dt = 0.01,
         )
-        @test_throws AssertionError WeberProblem(
+        @test_throws AssertionError HamiltonianProblem(
             system,
             (0.0, 1.0),
             [1.0, 0.0, -1.0, 0.0],
@@ -199,11 +199,11 @@
         )
     end
 
-    @testset "WeberSolution" begin
+    @testset "HamiltonianSolution" begin
         prob = make_weber_problem(tspan = (0.0, 0.1))
         sol = solve(prob)
 
-        @test sol isa WeberSolution
+        @test sol isa HamiltonianSolution
         @test sol.retcode == :Success
         @test length(sol) > 1
         @test length(sol.t) == length(sol.q) == length(sol.p)
@@ -232,20 +232,20 @@
         # show methods
         io = IOBuffer()
         show(io, sol)
-        @test occursin("WeberSolution", String(take!(io)))
+        @test occursin("HamiltonianSolution", String(take!(io)))
 
         io = IOBuffer()
         show(io, MIME"text/plain"(), sol)
         str = String(take!(io))
-        @test occursin("WeberSolution", str)
+        @test occursin("HamiltonianSolution", str)
         @test occursin("retcode", str)
     end
 
-    @testset "WeberIntegrator" begin
+    @testset "HamiltonianIntegrator" begin
         prob = make_weber_problem()
         integrator = init(prob)
 
-        @test integrator isa WeberIntegrator
+        @test integrator isa HamiltonianIntegrator
         @test integrator.t == prob.tspan[1]
         @test integrator.q == prob.q_initial
         @test integrator.p == prob.p_initial
@@ -254,17 +254,17 @@
         # show method
         io = IOBuffer()
         show(io, integrator)
-        @test occursin("WeberIntegrator", String(take!(io)))
+        @test occursin("HamiltonianIntegrator", String(take!(io)))
     end
 
-    @testset "WeberSystem display" begin
-        system = WeberSystem(2, 2)
+    @testset "HamiltonianSystem display" begin
+        system = HamiltonianSystem(2, 2)
 
         # show(io, system)
         io = IOBuffer()
         show(io, system)
         str = String(take!(io))
-        @test occursin("WeberSystem", str)
+        @test occursin("HamiltonianSystem", str)
         @test occursin("2 particles", str)
         @test occursin("2D", str)
         @test occursin("4 DOF", str)
@@ -273,7 +273,7 @@
         io = IOBuffer()
         show(io, MIME"text/plain"(), system)
         str = String(take!(io))
-        @test occursin("WeberSystem", str)
+        @test occursin("HamiltonianSystem", str)
         @test occursin("Particles: 2", str)
         @test occursin("Dimensions: 2", str)
     end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -15,14 +15,14 @@ function make_weber_problem(;
     q1 = sqrt(abs(k))
     q2 = -sign(k) * sqrt(abs(k))  # q1*q2 = -|k|*sign(k) = k for k < 0
 
-    system = WeberSystem(2, 2)
+    system = HamiltonianSystem(2, 2)
 
     r0 = 2.0
     M = m1 + m2
     v_circ = sqrt(abs(k) * M / (m1 * m2 * r0))
     q0 = [-m2 / M * r0, 0.0, m1 / M * r0, 0.0]
     p0 = [0.0, m1 * (-m2 / M * v_circ * 0.9), 0.0, m2 * (m1 / M * v_circ * 0.9)]
-    WeberProblem(system, tspan, q0, p0; masses = [m1, m2], charges = [q1, q2], c = c, dt = dt)
+    HamiltonianProblem(system, tspan, q0, p0; masses = [m1, m2], charges = [q1, q2], c = c, dt = dt)
 end
 
 """
@@ -41,14 +41,14 @@ function make_coulomb_like_problem(;
     q1 = sqrt(k)
     q2 = -sqrt(k)  # q1*q2 = -k (attractive)
 
-    system = WeberSystem(2, 2)
+    system = HamiltonianSystem(2, 2)
 
     r0 = 2.0
     M = m1 + m2
     v_circ = sqrt(k * M / (m1 * m2 * r0))
     q0 = [-m2 / M * r0, 0.0, m1 / M * r0, 0.0]
     p0 = [0.0, m1 * (-m2 / M * v_circ), 0.0, m2 * (m1 / M * v_circ)]
-    WeberProblem(system, tspan, q0, p0; masses = [m1, m2], charges = [q1, q2], c = 1e10, dt = dt)
+    HamiltonianProblem(system, tspan, q0, p0; masses = [m1, m2], charges = [q1, q2], c = 1e10, dt = dt)
 end
 
 # =============================================================================

--- a/test/test_zollner.jl
+++ b/test/test_zollner.jl
@@ -23,8 +23,8 @@
     end
 
     @testset "Kappa computation — unlike charges" begin
-        sys = WeberSystem(2, 2)
-        prob = WeberProblem(
+        sys = HamiltonianSystem(2, 2)
+        prob = HamiltonianProblem(
             sys, (0.0, 1.0),
             [1.0, 0.0, -1.0, 0.0], [0.0, 0.0, 0.0, 0.0];
             masses = [1.0, 1.0], charges = [1.0, -1.0], c = 10.0, dt = 0.01,
@@ -37,8 +37,8 @@
     end
 
     @testset "Kappa computation — like charges" begin
-        sys = WeberSystem(2, 2)
-        prob = WeberProblem(
+        sys = HamiltonianSystem(2, 2)
+        prob = HamiltonianProblem(
             sys, (0.0, 1.0),
             [1.0, 0.0, -1.0, 0.0], [0.0, 0.0, 0.0, 0.0];
             masses = [1.0, 1.0], charges = [1.0, 1.0], c = 10.0, dt = 0.01,
@@ -53,9 +53,9 @@
         # Pair (1,2): unlike → κ = 1+a
         # Pair (1,3): like   → κ = 1
         # Pair (2,3): unlike → κ = 1+a
-        sys = WeberSystem(3, 2)
+        sys = HamiltonianSystem(3, 2)
         a = 0.05
-        prob = WeberProblem(
+        prob = HamiltonianProblem(
             sys, (0.0, 1.0),
             [1.0, 0.0, 0.0, 0.0, -1.0, 0.0], zeros(6);
             masses = [1.0, 1.0, 1.0], charges = [1.0, -1.0, 1.0],
@@ -70,12 +70,12 @@
     @testset "Params vector length" begin
         # For N particles: params length = 2N + 1 + N*(N-1)/2
         for N in [2, 3, 4]
-            sys = WeberSystem(N, 2)
+            sys = HamiltonianSystem(N, 2)
             q0 = zeros(N * 2)
             q0[1] = 1.0
             p0 = zeros(N * 2)
             charges = [(-1)^i * 1.0 for i in 1:N]
-            prob = WeberProblem(
+            prob = HamiltonianProblem(
                 sys, (0.0, 1.0), q0, p0;
                 masses = ones(N), charges = charges, c = 10.0, dt = 0.01,
             )
@@ -90,8 +90,8 @@
 
     @testset "Zöllner disabled ≡ κ=1 physics" begin
         # A disabled Zöllner with any a should give κ=1 for all pairs
-        sys = WeberSystem(2, 2)
-        prob_off = WeberProblem(
+        sys = HamiltonianSystem(2, 2)
+        prob_off = HamiltonianProblem(
             sys, (0.0, 1.0),
             [1.0, 0.0, -1.0, 0.0], [0.0, 0.1, 0.0, -0.1];
             masses = [1.0, 1.0], charges = [1.0, -1.0], c = 10.0, dt = 0.01,
@@ -104,8 +104,8 @@
 
     @testset "Integration runs with Zöllner enabled" begin
         # Smoke test: ensure the solver accepts and runs a Zöllner-modified problem
-        sys = WeberSystem(2, 2)
-        prob = WeberProblem(
+        sys = HamiltonianSystem(2, 2)
+        prob = HamiltonianProblem(
             sys, (0.0, 0.1),
             [1.0, 0.0, -1.0, 0.0], [0.0, 0.3, 0.0, -0.3];
             masses = [1.0, 1.0], charges = [1.0, -1.0], c = 10.0, dt = 0.005,
@@ -124,10 +124,10 @@
     end
 
     @testset "Zöllner energy statistics" begin
-        sys = WeberSystem(2, 2)
+        sys = HamiltonianSystem(2, 2)
 
         # Disabled: Zöllner residual should be zero everywhere
-        prob_off = WeberProblem(
+        prob_off = HamiltonianProblem(
             sys, (0.0, 0.1),
             [1.0, 0.0, -1.0, 0.0], [0.0, 0.3, 0.0, -0.3];
             masses = [1.0, 1.0], charges = [1.0, -1.0], c = 10.0, dt = 0.005,
@@ -140,7 +140,7 @@
         @test all(x -> x ≈ 0.0, pair_off.zollner_extra_potential)
 
         # Enabled with unlike charges: Zöllner residual should be nonzero
-        prob_on = WeberProblem(
+        prob_on = HamiltonianProblem(
             sys, (0.0, 0.1),
             [1.0, 0.0, -1.0, 0.0], [0.0, 0.3, 0.0, -0.3];
             masses = [1.0, 1.0], charges = [1.0, -1.0], c = 10.0, dt = 0.005,
@@ -159,8 +159,8 @@
         # Both features can be enabled simultaneously without errors.
         # Orbit is stable (no close encounter) so regularization stays idle,
         # but the infrastructure must accept both flags at once.
-        sys = WeberSystem(2, 2)
-        prob = WeberProblem(
+        sys = HamiltonianSystem(2, 2)
+        prob = HamiltonianProblem(
             sys, (0.0, 0.5),
             [1.0, 0.0, -1.0, 0.0], [0.0, 0.5, 0.0, -0.5];
             masses = [1.0, 1.0], charges = [1.0, -1.0], c = 10.0, dt = 0.005,
@@ -186,10 +186,10 @@
         M = m1 + m2
         v_circ = sqrt(abs(q1 * q2) * M / (m1 * m2 * r0))
 
-        sys = WeberSystem(2, 2)
+        sys = HamiltonianSystem(2, 2)
         q0 = [-m2 / M * r0, 0.0, m1 / M * r0, 0.0]
         p0 = [0.0, m1 * (-m2 / M) * v_circ, 0.0, m2 * (m1 / M) * v_circ]
-        prob = WeberProblem(
+        prob = HamiltonianProblem(
             sys, (0.0, 1.0), q0, p0;
             masses = [m1, m2], charges = [q1, q2], c = c, dt = 0.001,
             zollner = ZollnerOptions(enabled = true, a = a),


### PR DESCRIPTION
## Summary

Phase 1b of the architectural refactor: mechanical rename of the four public types from Weber*-prefixed to Hamiltonian*-prefixed, preparing the surface for generic Hamiltonian use beyond Weber (the next phases will introduce `weber_term`/`zollner_term` builders on top of the new generic names).

- `WeberSystem` → `HamiltonianSystem`
- `WeberProblem` → `HamiltonianProblem`
- `WeberSolution` → `HamiltonianSolution`
- `WeberIntegrator` → `HamiltonianIntegrator`
- `src/weber_system.jl` → `src/hamiltonian_system.jl`
- `test/test_weber_system.jl` → `test/test_hamiltonian_system.jl`

## Numerical equivalence

- All 20356 tests pass.
- All 4 regression fixtures within 1e-12:
  - `twobody_ellipse`, `close_approach_lifted`, `zollner_offmatch`: exact
  - `threebody_mixed`: |Δq|=8.13e-20, |Δp|=6.51e-19 (Float64 noise from prior CSE in Phase 1a's extra `t` scope parameter; already accepted there)

## Scope note

`_research/` (36 files, 105 occurrences) intentionally NOT swept — handled in a dedicated follow-up PR per the plan's Phase 6 design. `_research/` notebooks that reference `WeberSystem`/`WeberProblem` will fail until that sweep lands. Main package + tests + docs + extensions are fully up to date.

## Test plan
- [x] Package precompiles on `main` baseline Julia
- [x] `Pkg.test()` — 20356 / 20356 green
- [x] `test/regression/validate.jl` — 4 / 4 pass at 1e-12 tolerance
- [x] CI Julia 1/1.9 on linux/macos/windows (pending on this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)