### PR TITLE
refactor: add NamedTerm + terms field on HamiltonianSystem

### DIFF
--- a/src/WeberElectrodynamics.jl
+++ b/src/WeberElectrodynamics.jl
@@ -10,6 +10,7 @@ export @sprintf, norm, dot
 # =============================================================================
 include("hamiltonian_system.jl")
 export HamiltonianSystem, weber_term, zollner_term
+export NamedTerm, term_names, has_term, get_term
 
 # =============================================================================
 # Core Types (Problem, Solution, Integrator)

--- a/src/hamiltonian/terms.jl
+++ b/src/hamiltonian/terms.jl
@@ -1,0 +1,55 @@
+"""
+    NamedTerm(name, H_symbolic; pair_decomposition = nothing)
+
+Named component of a composite Hamiltonian: a symbol that identifies the
+physical role (e.g. `:weber`, `:zollner`) and the symbolic expression
+contributing to the total `H`. Stored on `HamiltonianSystem` as
+`terms::Vector{NamedTerm}` so statistics and plotting can query individual
+contributions without re-deriving them from the compiled aggregate.
+
+The optional `pair_decomposition` closure returns a per-pair decomposition of
+the term's contribution, evaluated on concrete `(i, j, q, p, params)` inputs.
+The shape of the returned tuple is term-specific; the Weber and Zöllner
+builders will attach compatible closures in Phase 4 when statistics migrate
+onto this interface.
+
+# Fields
+- `name::Symbol`: Identifier used by `get_term`, `has_term`, `term_names`.
+- `H_symbolic`: Symbolic expression contributing to the aggregate Hamiltonian.
+- `pair_decomposition::Union{Function,Nothing}`: Optional closure
+  `(i, j, q, p, params) -> NamedTuple` for per-pair statistics.
+"""
+struct NamedTerm{H,F}
+    name::Symbol
+    H_symbolic::H
+    pair_decomposition::F
+end
+
+NamedTerm(name::Symbol, H_symbolic; pair_decomposition = nothing) =
+    NamedTerm(name, H_symbolic, pair_decomposition)
+
+"""
+    term_names(sys::HamiltonianSystem) -> Vector{Symbol}
+
+Return the names of every `NamedTerm` on `sys`, in insertion order.
+"""
+term_names(terms::AbstractVector{<:NamedTerm}) = Symbol[t.name for t in terms]
+
+"""
+    has_term(sys::HamiltonianSystem, name::Symbol) -> Bool
+
+Return `true` if `sys` carries a `NamedTerm` called `name`.
+"""
+has_term(terms::AbstractVector{<:NamedTerm}, name::Symbol) =
+    any(t -> t.name === name, terms)
+
+"""
+    get_term(sys::HamiltonianSystem, name::Symbol) -> NamedTerm
+
+Return the `NamedTerm` called `name`. Throws `KeyError` if absent.
+"""
+function get_term(terms::AbstractVector{<:NamedTerm}, name::Symbol)
+    idx = findfirst(t -> t.name === name, terms)
+    idx === nothing && throw(KeyError(name))
+    return terms[idx]
+end

--- a/src/hamiltonian_system.jl
+++ b/src/hamiltonian_system.jl
@@ -1,6 +1,8 @@
 using Symbolics
 using Latexify: latexify
 
+include("hamiltonian/terms.jl")
+
 """
     HamiltonianSystem
 
@@ -25,8 +27,12 @@ and code generation via Symbolics.jl; expect a few seconds for the first call.
   In-place compiled equations of motion. `t` is currently unused.
 - `hamiltonian_compiled(q, p, t, params)`: Compiled scalar Hamiltonian function.
 - `degrees_of_freedom::Int`: Total DOF = `n_particles × dims`.
+- `terms::Vector{NamedTerm}`: Named components of the Hamiltonian (e.g.
+  `:weber`, `:zollner`) preserving the decomposition for per-term statistics
+  and plotting. The generic constructor assigns a single `:hamiltonian` term
+  by default; specialized constructors populate richer decompositions.
 """
-struct HamiltonianSystem{H,QD,PD,QF,PF,HF,PS}
+struct HamiltonianSystem{H,QD,PD,QF,PF,HF,PS,TS<:AbstractVector{<:NamedTerm}}
     n_particles::Int
     dims::Int
 
@@ -44,6 +50,8 @@ struct HamiltonianSystem{H,QD,PD,QF,PF,HF,PS}
     hamiltonian_compiled::HF
 
     degrees_of_freedom::Int
+
+    terms::TS
 end
 
 function _generate_phase_space_symbols(n_particles::Int, dims::Int)
@@ -107,6 +115,9 @@ zollner_term(…)`). For the default pure Weber case, the convenience constructo
 - `param_symbols`: Symbolic parameter vector passed to `build_function`.
 - `t`: Symbolic time variable (reserved; may be unused).
 - `n_particles::Int`, `dims::Int`: Problem shape.
+- `terms`: Optional `Vector{NamedTerm}` naming the components of `H`. If
+  omitted, a single `NamedTerm(:hamiltonian, H)` is stored so queries like
+  `get_term(sys, :hamiltonian)` still work.
 """
 function HamiltonianSystem(
     H,
@@ -116,6 +127,7 @@ function HamiltonianSystem(
     t,
     n_particles::Int,
     dims::Int,
+    terms::Union{Nothing,AbstractVector{<:NamedTerm}} = nothing,
 )
     dq_dt_symbolic = [Symbolics.derivative(H, p_vars[i]) for i in eachindex(p_vars)]
     dp_dt_symbolic = [-Symbolics.derivative(H, q_vars[i]) for i in eachindex(q_vars)]
@@ -132,6 +144,8 @@ function HamiltonianSystem(
 
     degrees_of_freedom = n_particles * dims
 
+    resolved_terms = terms === nothing ? [NamedTerm(:hamiltonian, H)] : collect(terms)
+
     HamiltonianSystem(
         n_particles,
         dims,
@@ -146,6 +160,7 @@ function HamiltonianSystem(
         dp_dt_compiled,
         hamiltonian_compiled,
         degrees_of_freedom,
+        resolved_terms,
     )
 end
 
@@ -197,8 +212,20 @@ function HamiltonianSystem(n_particles::Int, dims::Int)
         t = t_var,
         n_particles = n_particles,
         dims = dims,
+        terms = [NamedTerm(:weber, H)],
     )
 end
+
+"""
+    term_names(sys::HamiltonianSystem) -> Vector{Symbol}
+    has_term(sys::HamiltonianSystem, name::Symbol) -> Bool
+    get_term(sys::HamiltonianSystem, name::Symbol) -> NamedTerm
+
+Query the named Hamiltonian components stored on `sys`.
+"""
+term_names(sys::HamiltonianSystem) = term_names(sys.terms)
+has_term(sys::HamiltonianSystem, name::Symbol) = has_term(sys.terms, name)
+get_term(sys::HamiltonianSystem, name::Symbol) = get_term(sys.terms, name)
 
 function Base.show(io::IO, sys::HamiltonianSystem)
     print(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,7 @@ using Symbolics
     include("test_types.jl")
     include("test_hamiltonian_system.jl")
     include("test_builders.jl")
+    include("test_named_term.jl")
     include("test_solve.jl")
     include("test_statistics.jl")
     include("test_integration.jl")

--- a/test/test_named_term.jl
+++ b/test/test_named_term.jl
@@ -1,0 +1,56 @@
+@testset "NamedTerm queries" begin
+    @testset "convenience ctor tags the Weber term" begin
+        sys = HamiltonianSystem(3, 2)
+        @test term_names(sys) == [:weber]
+        @test has_term(sys, :weber)
+        @test !has_term(sys, :zollner)
+        t = get_term(sys, :weber)
+        @test t.name === :weber
+        @test isequal(t.H_symbolic, sys.hamiltonian_symbolic)
+        @test t.pair_decomposition === nothing
+    end
+
+    @testset "generic ctor defaults to :hamiltonian" begin
+        @variables x1 y1 x2 y2 px1 py1 px2 py2 m1 m2 tt
+        q = [x1, y1, x2, y2]
+        p = [px1, py1, px2, py2]
+        H = sum(p .^ 2) / 2
+        sys = HamiltonianSystem(
+            H, q, p;
+            param_symbols = [m1, m2], t = tt,
+            n_particles = 2, dims = 2,
+        )
+        @test term_names(sys) == [:hamiltonian]
+        @test_throws KeyError get_term(sys, :missing)
+    end
+
+    @testset "generic ctor accepts an explicit terms vector" begin
+        @variables x1 y1 x2 y2 x3 y3 px1 py1 px2 py2 px3 py3
+        @variables m1 m2 m3 q1 q2 q3 cc k12 k13 k23 tt
+        q_syms = [x1, y1, x2, y2, x3, y3]
+        p_syms = [px1, py1, px2, py2, px3, py3]
+        param_syms = [m1, m2, m3, q1, q2, q3, cc, k12, k13, k23]
+
+        H_pure = weber_term(
+            q_syms, p_syms;
+            masses = [m1, m2, m3], charges = [q1, q2, q3], c = cc,
+            kappas = [1.0, 1.0, 1.0], n_particles = 3, dims = 2,
+        )
+        H_corr = zollner_term(
+            q_syms, p_syms;
+            masses = [m1, m2, m3], charges = [q1, q2, q3], c = cc,
+            kappas = [k12, k13, k23], n_particles = 3, dims = 2,
+        )
+        sys = HamiltonianSystem(
+            H_pure + H_corr, q_syms, p_syms;
+            param_symbols = param_syms, t = tt,
+            n_particles = 3, dims = 2,
+            terms = [NamedTerm(:weber, H_pure), NamedTerm(:zollner, H_corr)],
+        )
+
+        @test term_names(sys) == [:weber, :zollner]
+        @test has_term(sys, :weber) && has_term(sys, :zollner)
+        @test isequal(get_term(sys, :weber).H_symbolic, H_pure)
+        @test isequal(get_term(sys, :zollner).H_symbolic, H_corr)
+    end
+end


### PR DESCRIPTION
## Summary
- New `NamedTerm{name, H_symbolic, pair_decomposition}` struct in `src/hamiltonian/terms.jl` — foundation for per-term queries used by statistics and plotting.
- `HamiltonianSystem` gains `terms::Vector{NamedTerm}`. Generic ctor defaults to a single `:hamiltonian` term and accepts an explicit `terms=` kwarg; the convenience `HamiltonianSystem(n, dims)` tags its component as `:weber`.
- Accessors `term_names`, `has_term`, `get_term` exported.
- New `test/test_named_term.jl` (12 assertions) covering convenience tagging, generic default, and explicit multi-term construction with weber + zollner builders.

Phase 1f of the architectural refactor. No runtime behaviour change — regression fixtures agree with main at Float64 noise (worst `|Δp| = 6.5e-19` on `threebody_mixed`).

## Test plan
- [x] `julia --project=. -e 'using Pkg; Pkg.test()'` → 20374 tests pass
- [x] `julia --project=. -e 'include("test/regression/validate.jl"); validate_all()'` → all 4 fixtures PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)