### PR TITLE
refactor: add accessor API for HamiltonianSystem and HamiltonianProblem

### DIFF
--- a/src/WeberElectrodynamics.jl
+++ b/src/WeberElectrodynamics.jl
@@ -11,6 +11,7 @@ export @sprintf, norm, dot
 include("hamiltonian_system.jl")
 export HamiltonianSystem, weber_term, zollner_term
 export NamedTerm, term_names, has_term, get_term
+export n_particles, dims, degrees_of_freedom
 
 # =============================================================================
 # Core Types (Problem, Solution, Integrator)
@@ -23,6 +24,7 @@ export RegularizationOptions
 export RegularizationDiagnostics
 export ZollnerOptions
 export SymmetricProjectionIntegrator
+export masses, charges, speed_of_light, kappas, params
 
 # =============================================================================
 # Regularization Helpers

--- a/src/hamiltonian_system.jl
+++ b/src/hamiltonian_system.jl
@@ -227,6 +227,18 @@ term_names(sys::HamiltonianSystem) = term_names(sys.terms)
 has_term(sys::HamiltonianSystem, name::Symbol) = has_term(sys.terms, name)
 get_term(sys::HamiltonianSystem, name::Symbol) = get_term(sys.terms, name)
 
+"""
+    n_particles(sys::HamiltonianSystem) -> Int
+    dims(sys::HamiltonianSystem) -> Int
+    degrees_of_freedom(sys::HamiltonianSystem) -> Int
+
+Read-only accessors for the problem shape. Prefer these over direct field
+access so extensions stay stable across future Hamiltonian shapes.
+"""
+n_particles(sys::HamiltonianSystem) = sys.n_particles
+dims(sys::HamiltonianSystem) = sys.dims
+degrees_of_freedom(sys::HamiltonianSystem) = sys.degrees_of_freedom
+
 function Base.show(io::IO, sys::HamiltonianSystem)
     print(
         io,

--- a/src/types.jl
+++ b/src/types.jl
@@ -533,6 +533,27 @@ struct HamiltonianProblem
 end
 
 """
+    n_particles(prob::HamiltonianProblem) -> Int
+    dims(prob::HamiltonianProblem) -> Int
+    masses(prob::HamiltonianProblem) -> Vector{Float64}
+    charges(prob::HamiltonianProblem) -> Vector{Float64}
+    speed_of_light(prob::HamiltonianProblem) -> Float64
+    kappas(prob::HamiltonianProblem) -> Vector{Float64}
+    params(prob::HamiltonianProblem) -> Vector{Float64}
+
+Read-only accessors. Extensions and statistics should use these instead of
+direct field access so that later refactors (dropping `masses`/`charges`/etc.
+from the struct in favor of a flat `params` vector) remain source-compatible.
+"""
+n_particles(prob::HamiltonianProblem) = n_particles(prob.system)
+dims(prob::HamiltonianProblem) = dims(prob.system)
+masses(prob::HamiltonianProblem) = prob.masses
+charges(prob::HamiltonianProblem) = prob.charges
+speed_of_light(prob::HamiltonianProblem) = prob.c
+kappas(prob::HamiltonianProblem) = prob.kappas
+params(prob::HamiltonianProblem) = prob.params
+
+"""
     HamiltonianSolution
 
 Result returned by `solve` or `solve!`.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,7 @@ using Symbolics
     include("test_hamiltonian_system.jl")
     include("test_builders.jl")
     include("test_named_term.jl")
+    include("test_accessors.jl")
     include("test_solve.jl")
     include("test_statistics.jl")
     include("test_integration.jl")

--- a/test/test_accessors.jl
+++ b/test/test_accessors.jl
@@ -1,0 +1,47 @@
+@testset "Accessor API" begin
+    sys = HamiltonianSystem(3, 2)
+
+    @testset "HamiltonianSystem shape accessors" begin
+        @test n_particles(sys) == 3
+        @test dims(sys) == 2
+        @test degrees_of_freedom(sys) == 6
+    end
+
+    @testset "HamiltonianProblem parameter accessors" begin
+        prob = HamiltonianProblem(
+            sys, (0.0, 1.0), zeros(6), zeros(6);
+            masses = [1.0, 2.0, 3.0],
+            charges = [1.0, -1.0, 0.5],
+            c = 10.0,
+            dt = 0.01,
+        )
+
+        @test n_particles(prob) == 3
+        @test dims(prob) == 2
+        @test masses(prob) == [1.0, 2.0, 3.0]
+        @test charges(prob) == [1.0, -1.0, 0.5]
+        @test speed_of_light(prob) == 10.0
+        @test kappas(prob) == ones(3)
+
+        # params layout: [m₁…mₙ, q₁…qₙ, c, κ₁₂, κ₁₃, κ₂₃]
+        @test length(params(prob)) == 2*3 + 1 + 3
+        @test params(prob)[1:3] == masses(prob)
+        @test params(prob)[4:6] == charges(prob)
+        @test params(prob)[7] == speed_of_light(prob)
+        @test params(prob)[8:10] == kappas(prob)
+    end
+
+    @testset "zollner injects κ accessor" begin
+        prob = HamiltonianProblem(
+            sys, (0.0, 1.0), zeros(6), zeros(6);
+            masses = [1.0, 1.0, 1.0],
+            charges = [1.0, -1.0, 1.0],
+            c = 10.0,
+            dt = 0.01,
+            zollner = ZollnerOptions(enabled = true, a = 0.1),
+        )
+        # pairs (1,2) and (2,3) are unlike-sign → κ = 1.1; (1,3) like-sign → κ = 1
+        κ = kappas(prob)
+        @test κ ≈ [1.1, 1.0, 1.1]
+    end
+end


### PR DESCRIPTION
## Summary
- New read-only accessors on `HamiltonianSystem`: `n_particles`, `dims`, `degrees_of_freedom`.
- New accessors on `HamiltonianProblem`: `n_particles`, `dims`, `masses`, `charges`, `speed_of_light`, `kappas`, `params`.
- Prep work for later phases that drop `masses`/`charges`/`c`/`kappas` as struct fields (source-compatible once consumers route through accessors).

No runtime behaviour change. Regression fixtures pass at Float64 noise (`|Δp| ≤ 6.5e-19`).

## Test plan
- [x] `julia --project=. -e 'using Pkg; Pkg.test()'` → 20389 tests pass (15 new accessor tests).
- [x] All 4 regression fixtures PASS at tolerance 1e-12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)