### PR TITLE
refactor: rename WeberAlgorithm → HamiltonianAlgorithm, add _step_core! dispatch hook

### DIFF
--- a/ext/WeberElectrodynamicsMakieExt.jl
+++ b/ext/WeberElectrodynamicsMakieExt.jl
@@ -3,7 +3,7 @@ module WeberElectrodynamicsMakieExt
 using WeberElectrodynamics
 using WeberElectrodynamics: @sprintf, norm, dot,
     HamiltonianProblem, HamiltonianIntegrator, HamiltonianSystem, HamiltonianSolution,
-    SymmetricProjectionIntegrator, WeberAlgorithm,
+    SymmetricProjectionIntegrator, HamiltonianAlgorithm,
     _pair_index, compute_total_kinetic_energy, compute_pair_weber_components
 using CommonSolve: init, step!
 using Makie

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -774,6 +774,36 @@ end
     return nothing
 end
 
+# -----------------------------------------------------------------------------
+# Algorithm dispatch hook
+#
+# `_step_core!(integrator, alg, dt_step)` advances the integrator by one
+# macro-step under the requested algorithm. New algorithms plug into the
+# integrator by adding a method to this function — no edits needed in the
+# outer `step!` loop. The default method errors so that unsupported
+# algorithms fail loudly rather than silently falling back.
+# -----------------------------------------------------------------------------
+function _step_core!(
+    ::HamiltonianIntegrator,
+    alg::HamiltonianAlgorithm,
+    ::Float64,
+)
+    throw(ArgumentError("step! not implemented for algorithm $(typeof(alg))"))
+end
+
+@inline function _step_core!(
+    integrator::HamiltonianIntegrator,
+    ::SymmetricProjectionIntegrator,
+    dt_step::Float64,
+)
+    if integrator.prob.regularization.enabled
+        _step_regularized_dispatch!(integrator, dt_step)
+    else
+        _step_unregularized!(integrator, dt_step)
+    end
+    return nothing
+end
+
 @inline function _step_regularized_pair_adaptive!(
     integrator::HamiltonianIntegrator,
     dt_step::Float64,
@@ -1170,11 +1200,7 @@ function CommonSolve.step!(integrator::HamiltonianIntegrator)
         )
     end
 
-    if prob.regularization.enabled
-        _step_regularized_dispatch!(integrator, dt_step)
-    else
-        _step_unregularized!(integrator, dt_step)
-    end
+    _step_core!(integrator, integrator.alg, dt_step)
 
     return integrator.step_count < max_steps
 end
@@ -1217,7 +1243,7 @@ function CommonSolve.solve!(integrator::HamiltonianIntegrator)
 end
 
 """
-    solve(prob::HamiltonianProblem, alg::WeberAlgorithm = SymmetricProjectionIntegrator()) -> HamiltonianSolution
+    solve(prob::HamiltonianProblem, alg::HamiltonianAlgorithm = SymmetricProjectionIntegrator()) -> HamiltonianSolution
 
 Initialise and run the integrator in a single call.
 
@@ -1228,7 +1254,7 @@ Convenience wrapper equivalent to `solve!(init(prob, alg))`.
 """
 function CommonSolve.solve(
     prob::HamiltonianProblem,
-    alg::WeberAlgorithm = SymmetricProjectionIntegrator(),
+    alg::HamiltonianAlgorithm = SymmetricProjectionIntegrator(),
 )
     integrator = CommonSolve.init(prob, alg)
     CommonSolve.solve!(integrator)

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,6 +1,6 @@
 using LinearAlgebra
 
-abstract type WeberAlgorithm end
+abstract type HamiltonianAlgorithm end
 
 const REG_MODE_NONE = UInt8(0)
 const REG_MODE_PAIR = UInt8(1)
@@ -28,7 +28,7 @@ iteration whose convergence is controlled by `relaxation`.
 # Fields
 - `relaxation::Float64`: Stored relaxation factor.
 """
-struct SymmetricProjectionIntegrator <: WeberAlgorithm
+struct SymmetricProjectionIntegrator <: HamiltonianAlgorithm
     relaxation::Float64
 
     function SymmetricProjectionIntegrator(; relaxation::Real = 0.25)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,7 @@ using Symbolics
     include("test_builders.jl")
     include("test_named_term.jl")
     include("test_accessors.jl")
+    include("test_algorithm_dispatch.jl")
     include("test_solve.jl")
     include("test_statistics.jl")
     include("test_integration.jl")

--- a/test/test_algorithm_dispatch.jl
+++ b/test/test_algorithm_dispatch.jl
@@ -1,0 +1,36 @@
+@testset "Algorithm dispatch hook" begin
+    @testset "SymmetricProjectionIntegrator <: HamiltonianAlgorithm" begin
+        @test SymmetricProjectionIntegrator <: WeberElectrodynamics.HamiltonianAlgorithm
+    end
+
+    @testset "_step_core! dispatches on algorithm" begin
+        # The internal step hook is the documented extension point. A
+        # specialized method exists for SymmetricProjectionIntegrator; the
+        # default method on any other HamiltonianAlgorithm subtype errors.
+        @test hasmethod(
+            WeberElectrodynamics._step_core!,
+            Tuple{
+                WeberElectrodynamics.HamiltonianIntegrator,
+                SymmetricProjectionIntegrator,
+                Float64,
+            },
+        )
+    end
+
+    @testset "solve! routes through _step_core!" begin
+        # Regression: the outer step! loop must call _step_core!, not an
+        # inline branch. If someone re-inlines the regularized/unregularized
+        # branching, this test still passes — but the regression fixtures
+        # catch any numerical drift.
+        sys = HamiltonianSystem(2, 2)
+        prob = HamiltonianProblem(
+            sys, (0.0, 0.05), [1.0, 0.0, -1.0, 0.0], [0.0, 0.1, 0.0, -0.1];
+            masses = [1.0, 1.0],
+            charges = [1.0, -1.0],
+            c = 100.0,
+            dt = 0.01,
+        )
+        sol = solve(prob, SymmetricProjectionIntegrator())
+        @test sol.retcode === :Success
+    end
+end


### PR DESCRIPTION
## Summary
- Rename `abstract type WeberAlgorithm` → `HamiltonianAlgorithm` (internal; only reference was in the Makie extension).
- Introduce `_step_core!(integrator, alg, dt_step)` as the stable per-algorithm dispatch point. Default method throws `ArgumentError` so unsupported algorithms fail loudly; `SymmetricProjectionIntegrator` specialization preserves current behaviour.
- Outer `step!` loop now delegates to `_step_core!` instead of inline-branching on `prob.regularization.enabled`.

Phase 2 of the refactor — this is the extension point that Phase 3's `RegularizedIntegrator` will plug into.

No runtime behaviour change. Regression fixtures at Float64 noise (`|Δp| ≤ 6.5e-19`).

## Test plan
- [x] `julia --project=. -e 'using Pkg; Pkg.test()'` → 20392 tests pass
- [x] All 4 regression fixtures PASS at tolerance 1e-12
- [x] New `test/test_algorithm_dispatch.jl` covering subtype relationship + method presence + end-to-end solve

🤖 Generated with [Claude Code](https://claude.com/claude-code)