### PR TITLE
refactor: add _allocate_cache hook + parameterize HamiltonianIntegrator

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -1080,8 +1080,29 @@ end
     return out
 end
 
+# -----------------------------------------------------------------------------
+# Cache allocation hook
+#
+# `_allocate_cache(prob, alg)` builds the algorithm-specific workspace used by
+# `_step_core!`. New algorithms plug in by adding a method here rather than
+# modifying `init`. The default method errors so that unsupported algorithms
+# fail during init rather than silently running with wrong buffers.
+# -----------------------------------------------------------------------------
+function _allocate_cache(::HamiltonianProblem, alg::HamiltonianAlgorithm)
+    throw(ArgumentError("init not implemented for algorithm $(typeof(alg))"))
+end
+
+function _allocate_cache(prob::HamiltonianProblem, ::SymmetricProjectionIntegrator)
+    buffers = SymmetricProjectionBuffers(prob)
+    rb = buffers.regularization_buffers
+    if prob.regularization.enabled && rb.backend_fallback && prob.regularization.warn_on_fallback
+        @warn "RegularizationOptions(backend=:lifted_pair) is currently supported only for 2D; falling back to :adaptive_cartesian for $(prob.system.dims)D"
+    end
+    return buffers
+end
+
 """
-    init(prob::HamiltonianProblem, alg::SymmetricProjectionIntegrator = SymmetricProjectionIntegrator()) -> HamiltonianIntegrator
+    init(prob::HamiltonianProblem, alg::HamiltonianAlgorithm = SymmetricProjectionIntegrator()) -> HamiltonianIntegrator
 
 Initialise a step-by-step integrator without running any steps.
 
@@ -1094,12 +1115,11 @@ or pass it directly to `solve!`.
 """
 function CommonSolve.init(
     prob::HamiltonianProblem,
-    alg::SymmetricProjectionIntegrator = SymmetricProjectionIntegrator(),
+    alg::HamiltonianAlgorithm = SymmetricProjectionIntegrator(),
 )
     degrees_of_freedom = prob.system.degrees_of_freedom
 
-    buffers = SymmetricProjectionBuffers(prob)
-    rb = buffers.regularization_buffers
+    buffers = _allocate_cache(prob, alg)
 
     n_steps = Int(ceil((prob.tspan[2] - prob.tspan[1]) / prob.dt))
     t_history = Vector{Float64}(undef, n_steps + 1)
@@ -1114,10 +1134,6 @@ function CommonSolve.init(
     used_backend = REG_BACKEND_DISABLED
     diagnostics =
         RegularizationDiagnostics(prob.regularization.enabled, n_steps, requested_backend, used_backend)
-
-    if prob.regularization.enabled && rb.backend_fallback && prob.regularization.warn_on_fallback
-        @warn "RegularizationOptions(backend=:lifted_pair) is currently supported only for 2D; falling back to :adaptive_cartesian for $(prob.system.dims)D"
-    end
 
     HamiltonianIntegrator(
         prob,

--- a/src/types.jl
+++ b/src/types.jl
@@ -736,15 +736,15 @@ run to completion. The current state is accessible via `integrator.q`,
 - `q_history::Vector{Vector{Float64}}`: Pre-allocated position history.
 - `p_history::Vector{Vector{Float64}}`: Pre-allocated momentum history.
 """
-mutable struct HamiltonianIntegrator
+mutable struct HamiltonianIntegrator{A<:HamiltonianAlgorithm,C}
     prob::HamiltonianProblem
-    alg::SymmetricProjectionIntegrator
+    alg::A
     t::Float64
     t_end::Float64
     q::Vector{Float64}
     p::Vector{Float64}
     step_count::Int
-    buffers::SymmetricProjectionBuffers
+    buffers::C
     diagnostics::RegularizationDiagnostics
     t_history::Vector{Float64}
     q_history::Vector{Vector{Float64}}

--- a/test/test_algorithm_dispatch.jl
+++ b/test/test_algorithm_dispatch.jl
@@ -1,12 +1,14 @@
 @testset "Algorithm dispatch hook" begin
+    # Dummy algorithm with no _allocate_cache / _step_core! methods —
+    # should hit the default error path at init time so unsupported
+    # algorithms fail loudly.
+    struct _UnsupportedAlgorithm <: WeberElectrodynamics.HamiltonianAlgorithm end
+
     @testset "SymmetricProjectionIntegrator <: HamiltonianAlgorithm" begin
         @test SymmetricProjectionIntegrator <: WeberElectrodynamics.HamiltonianAlgorithm
     end
 
-    @testset "_step_core! dispatches on algorithm" begin
-        # The internal step hook is the documented extension point. A
-        # specialized method exists for SymmetricProjectionIntegrator; the
-        # default method on any other HamiltonianAlgorithm subtype errors.
+    @testset "dispatch methods exist for the built-in algorithm" begin
         @test hasmethod(
             WeberElectrodynamics._step_core!,
             Tuple{
@@ -15,22 +17,27 @@
                 Float64,
             },
         )
+        @test hasmethod(
+            WeberElectrodynamics._allocate_cache,
+            Tuple{HamiltonianProblem, SymmetricProjectionIntegrator},
+        )
     end
 
-    @testset "solve! routes through _step_core!" begin
-        # Regression: the outer step! loop must call _step_core!, not an
-        # inline branch. If someone re-inlines the regularized/unregularized
-        # branching, this test still passes — but the regression fixtures
-        # catch any numerical drift.
-        sys = HamiltonianSystem(2, 2)
-        prob = HamiltonianProblem(
-            sys, (0.0, 0.05), [1.0, 0.0, -1.0, 0.0], [0.0, 0.1, 0.0, -0.1];
-            masses = [1.0, 1.0],
-            charges = [1.0, -1.0],
-            c = 100.0,
-            dt = 0.01,
-        )
+    sys = HamiltonianSystem(2, 2)
+    prob = HamiltonianProblem(
+        sys, (0.0, 0.05), [1.0, 0.0, -1.0, 0.0], [0.0, 0.1, 0.0, -0.1];
+        masses = [1.0, 1.0],
+        charges = [1.0, -1.0],
+        c = 100.0,
+        dt = 0.01,
+    )
+
+    @testset "supported algorithm solves" begin
         sol = solve(prob, SymmetricProjectionIntegrator())
         @test sol.retcode === :Success
+    end
+
+    @testset "unsupported algorithm raises at init" begin
+        @test_throws ArgumentError solve(prob, _UnsupportedAlgorithm())
     end
 end


### PR DESCRIPTION
## Summary
- `HamiltonianIntegrator{A<:HamiltonianAlgorithm, C}` parameterized on algorithm + cache types so future algorithms (e.g. Phase 3c's `RegularizedIntegrator`) can bring their own cache type.
- New `_allocate_cache(prob, alg)` dispatch hook: default throws `ArgumentError`, specialized method for `SymmetricProjectionIntegrator` builds `SymmetricProjectionBuffers` and owns the `:lifted_pair → :adaptive_cartesian` fallback warning.
- `CommonSolve.init(prob, alg::HamiltonianAlgorithm)` replaces the `SymmetricProjectionIntegrator`-only signature.

Phase 3a — the last structural prep before `RegularizedIntegrator` lands. No runtime behaviour change. Regression fixtures at Float64 noise (`|Δp| ≤ 6.5e-19`).

## Test plan
- [x] `julia --project=. -e 'using Pkg; Pkg.test()'` → 20394 tests pass
- [x] All 4 regression fixtures PASS at tolerance 1e-12
- [x] `test_algorithm_dispatch.jl` verifies unsupported algorithms fail at `init` with `ArgumentError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)