### PR TITLE
refactor: add RegularizedIntegrator algorithm wrapper (Phase 3c.1)

### DIFF
--- a/src/WeberElectrodynamics.jl
+++ b/src/WeberElectrodynamics.jl
@@ -40,6 +40,12 @@ using CommonSolve: solve, init, step!, solve!
 export solve, init, step!, solve!
 
 # =============================================================================
+# Algorithm wrappers
+# =============================================================================
+include("integrators/regularized.jl")
+export RegularizedIntegrator
+
+# =============================================================================
 # Statistics & Analysis
 # =============================================================================
 include("statistics/trajectories.jl")

--- a/src/integrators/regularized.jl
+++ b/src/integrators/regularized.jl
@@ -1,0 +1,89 @@
+"""
+    RegularizedIntegrator{A}(base_alg::A; kwargs...)
+
+Algorithm wrapper that activates Levi-Civita / KS regularization on top of a
+base Hamiltonian algorithm. `kwargs` mirror [`RegularizationOptions`](@ref)
+and are forwarded verbatim; `enabled` is set to `true` implicitly.
+
+This is the user-facing entry point for regularized integration:
+
+```julia
+alg = RegularizedIntegrator(SymmetricProjectionIntegrator();
+                            r_on_factor = 0.15, backend = :lifted_pair)
+sol = solve(prob, alg)
+```
+
+The wrapper's options override `prob.regularization`; the base algorithm's
+settings (e.g. `relaxation`) are preserved.
+"""
+struct RegularizedIntegrator{A<:HamiltonianAlgorithm} <: HamiltonianAlgorithm
+    base_alg::A
+    options::RegularizationOptions
+end
+
+function RegularizedIntegrator(
+    base_alg::HamiltonianAlgorithm;
+    r_on::Union{Nothing,Real} = nothing,
+    r_off::Union{Nothing,Real} = nothing,
+    r_on_factor::Real = 0.15,
+    r_off_factor::Real = 0.25,
+    max_substeps::Integer = 512,
+    constraint_tolerance::Real = 1e-12,
+    g_floor::Real = 1e-12,
+    chain_enabled::Bool = true,
+    backend::Symbol = REG_BACKEND_LIFTED,
+    warn_on_fallback::Bool = true,
+    collision_bounce_radius::Real = 0.0,
+)
+    options = RegularizationOptions(
+        enabled = true,
+        r_on = r_on,
+        r_off = r_off,
+        r_on_factor = r_on_factor,
+        r_off_factor = r_off_factor,
+        max_substeps = max_substeps,
+        constraint_tolerance = constraint_tolerance,
+        g_floor = g_floor,
+        chain_enabled = chain_enabled,
+        backend = backend,
+        warn_on_fallback = warn_on_fallback,
+        collision_bounce_radius = collision_bounce_radius,
+    )
+    return RegularizedIntegrator(base_alg, options)
+end
+
+"""
+    base_algorithm(alg::HamiltonianAlgorithm) -> HamiltonianAlgorithm
+
+Unwrap an algorithm one level. For bare algorithms this is the identity; for
+[`RegularizedIntegrator`](@ref) it returns the wrapped base algorithm.
+"""
+base_algorithm(alg::HamiltonianAlgorithm) = alg
+base_algorithm(alg::RegularizedIntegrator) = alg.base_alg
+
+# Rewrite a HamiltonianProblem with a new `regularization` field. This is the
+# Phase 3c.1 shim that lets `RegularizedIntegrator` delegate to the existing
+# regularization dispatch code without refactoring hot-path option reads.
+# Phase 3d will drop `prob.regularization` entirely, at which point this
+# helper disappears and the dispatch reads options from the algorithm instead.
+function _with_regularization(prob::HamiltonianProblem, reg::RegularizationOptions)
+    return HamiltonianProblem(
+        prob.system,
+        prob.tspan,
+        prob.q_initial,
+        prob.p_initial;
+        masses = prob.masses,
+        charges = prob.charges,
+        c = prob.c,
+        dt = prob.dt,
+        convergence_tolerance = prob.convergence_tolerance,
+        maximum_iterations = prob.maximum_iterations,
+        regularization = reg,
+        zollner = prob.zollner,
+    )
+end
+
+function CommonSolve.init(prob::HamiltonianProblem, alg::RegularizedIntegrator)
+    effective_prob = _with_regularization(prob, alg.options)
+    return CommonSolve.init(effective_prob, alg.base_alg)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,7 @@ using Symbolics
     include("test_named_term.jl")
     include("test_accessors.jl")
     include("test_algorithm_dispatch.jl")
+    include("test_regularized_integrator.jl")
     include("test_solve.jl")
     include("test_statistics.jl")
     include("test_integration.jl")

--- a/test/test_regularized_integrator.jl
+++ b/test/test_regularized_integrator.jl
@@ -1,0 +1,117 @@
+using JLD2
+
+@testset "RegularizedIntegrator wrapper" begin
+    @testset "subtyping + unwrap" begin
+        base = SymmetricProjectionIntegrator(relaxation = 0.25)
+        alg = WeberElectrodynamics.RegularizedIntegrator(base; backend = :lifted_pair)
+        @test alg isa WeberElectrodynamics.HamiltonianAlgorithm
+        @test WeberElectrodynamics.base_algorithm(alg) === base
+        @test WeberElectrodynamics.base_algorithm(base) === base
+        @test alg.options.enabled === true
+        @test alg.options.backend === :lifted_pair
+        @test alg.options.r_on_factor == 0.15
+    end
+
+    @testset "options kwargs forwarded" begin
+        alg = WeberElectrodynamics.RegularizedIntegrator(
+            SymmetricProjectionIntegrator();
+            r_on_factor = 0.2,
+            r_off_factor = 0.5,
+            max_substeps = 64,
+            backend = :adaptive_cartesian,
+            chain_enabled = false,
+            warn_on_fallback = false,
+            collision_bounce_radius = 0.01,
+        )
+        @test alg.options.r_on_factor == 0.2
+        @test alg.options.r_off_factor == 0.5
+        @test alg.options.max_substeps == 64
+        @test alg.options.backend === :adaptive_cartesian
+        @test alg.options.chain_enabled === false
+        @test alg.options.warn_on_fallback === false
+        @test alg.options.collision_bounce_radius == 0.01
+    end
+
+    # The wrapper must produce trajectories numerically identical to those from
+    # the equivalent prob-level `regularization = ...` kwarg. This verifies the
+    # Phase 3c.1 shim — rewriting `prob.regularization` at init time — preserves
+    # bit-exact output against the existing regularization dispatch code.
+    @testset "equivalence with prob-level regularization" begin
+        fixture_path =
+            joinpath(@__DIR__, "regression", "fixtures", "close_approach_lifted.jld2")
+        fixture = jldopen(fixture_path, "r") do file
+            Dict{String,Any}(
+                "setup" => read(file, "setup"),
+                "trajectory" => read(file, "trajectory"),
+            )
+        end
+        setup = fixture["setup"]
+        reg_dict = setup["regularization"]
+        reg_opts = RegularizationOptions(
+            enabled = reg_dict["enabled"],
+            r_on = reg_dict["r_on"],
+            r_off = reg_dict["r_off"],
+            r_on_factor = reg_dict["r_on_factor"],
+            r_off_factor = reg_dict["r_off_factor"],
+            max_substeps = reg_dict["max_substeps"],
+            constraint_tolerance = reg_dict["constraint_tolerance"],
+            g_floor = reg_dict["g_floor"],
+            chain_enabled = reg_dict["chain_enabled"],
+            backend = Symbol(reg_dict["backend"]),
+            warn_on_fallback = reg_dict["warn_on_fallback"],
+            collision_bounce_radius = reg_dict["collision_bounce_radius"],
+        )
+
+        sys = HamiltonianSystem(setup["n_particles"]::Int, setup["dims"]::Int)
+        base_kwargs = (
+            masses = setup["masses"]::Vector{Float64},
+            charges = setup["charges"]::Vector{Float64},
+            c = setup["c"]::Float64,
+            dt = setup["dt"]::Float64,
+            convergence_tolerance = setup["convergence_tolerance"]::Float64,
+            maximum_iterations = setup["maximum_iterations"]::Int,
+        )
+
+        # Problem A: regularization baked into the problem (existing API).
+        prob_a = HamiltonianProblem(
+            sys,
+            Tuple(setup["tspan"]::Vector{Float64}),
+            setup["q_initial"]::Vector{Float64},
+            setup["p_initial"]::Vector{Float64};
+            base_kwargs...,
+            regularization = reg_opts,
+        )
+        sol_a = solve(prob_a, SymmetricProjectionIntegrator())
+
+        # Problem B: same setup but regularization via the algorithm wrapper.
+        prob_b = HamiltonianProblem(
+            sys,
+            Tuple(setup["tspan"]::Vector{Float64}),
+            setup["q_initial"]::Vector{Float64},
+            setup["p_initial"]::Vector{Float64};
+            base_kwargs...,
+        )
+        alg = WeberElectrodynamics.RegularizedIntegrator(
+            SymmetricProjectionIntegrator();
+            r_on = reg_opts.r_on,
+            r_off = reg_opts.r_off,
+            r_on_factor = reg_opts.r_on_factor,
+            r_off_factor = reg_opts.r_off_factor,
+            max_substeps = reg_opts.max_substeps,
+            constraint_tolerance = reg_opts.constraint_tolerance,
+            g_floor = reg_opts.g_floor,
+            chain_enabled = reg_opts.chain_enabled,
+            backend = reg_opts.backend,
+            warn_on_fallback = reg_opts.warn_on_fallback,
+            collision_bounce_radius = reg_opts.collision_bounce_radius,
+        )
+        sol_b = solve(prob_b, alg)
+
+        @test sol_a.retcode === sol_b.retcode
+        @test length(sol_a.t) == length(sol_b.t)
+        max_q = maximum(maximum(abs, sol_a.q[i] .- sol_b.q[i]) for i in eachindex(sol_a.q))
+        max_p = maximum(maximum(abs, sol_a.p[i] .- sol_b.p[i]) for i in eachindex(sol_a.p))
+        @test max_q == 0.0
+        @test max_p == 0.0
+    end
+end


### PR DESCRIPTION
## Summary
- Introduces `RegularizedIntegrator(base_alg; kwargs...)` as the new user-facing entry point for regularized integration.
- Kwargs mirror `RegularizationOptions`; `enabled` is set implicitly.
- Implementation is a thin shim: `init(prob, ::RegularizedIntegrator)` rewrites `prob.regularization` with the wrapper's options and forwards to the base algorithm. This preserves bit-exact numerical equivalence with the existing `prob.regularization = ...` kwarg path.

## Why a shim, not a deep refactor
The deep migration of regularization state off `prob` and onto the algorithm lands in **Phase 3d** when `prob.regularization` is dropped entirely. Keeping Phase 3c.1 as a shim lets us publish the new API surface now — users can already write `solve(prob, RegularizedIntegrator(SymmetricProjectionIntegrator(); ...))` — without touching the regularization hot loop and risking the 1e-12 numerical-equivalence invariant.

A planned Phase 3c.2 will add `CollisionBounce` as a proper callback; it's deferred here to keep this PR reviewable.

## Equivalence proof
New `test/test_regularized_integrator.jl` asserts:
- `max |Δq| = 0.0` and `max |Δp| = 0.0` between the wrapper path and the prob-level kwarg path on the `close_approach_lifted` regression fixture (regularization actively firing).
- Unwrap / subtyping / kwarg forwarding smoke tests.

All four regression fixtures still pass at 1e-12 on both paths. Full 20411-test suite green.

## Test plan
- [x] `julia --project=. -e 'using Pkg; Pkg.test()'` — 20411 / 20411 pass
- [x] `julia --project=. test/regression/validate.jl` — all four fixtures pass (|Δq| ≤ 8.13e-20)
- [x] New `test_regularized_integrator.jl` — 17 / 17 pass, including bit-exact equivalence on close-approach fixture

🤖 Generated with [Claude Code](https://claude.com/claude-code)