### PR TITLE
refactor: drop regularization field from HamiltonianProblem

### DIFF
--- a/src/WeberElectrodynamics.jl
+++ b/src/WeberElectrodynamics.jl
@@ -24,7 +24,7 @@ export RegularizationOptions
 export RegularizationDiagnostics
 export ZollnerOptions
 export SymmetricProjectionIntegrator
-export masses, charges, speed_of_light, kappas, params, regularization, zollner
+export masses, charges, speed_of_light, kappas, params, zollner
 
 # =============================================================================
 # Regularization Helpers

--- a/src/integrators/regularized.jl
+++ b/src/integrators/regularized.jl
@@ -13,8 +13,7 @@ alg = RegularizedIntegrator(SymmetricProjectionIntegrator();
 sol = solve(prob, alg)
 ```
 
-The wrapper's options override `prob.regularization`; the base algorithm's
-settings (e.g. `relaxation`) are preserved.
+The base algorithm's settings (e.g. `relaxation`) are preserved.
 """
 struct RegularizedIntegrator{A<:HamiltonianAlgorithm} <: HamiltonianAlgorithm
     base_alg::A
@@ -61,33 +60,33 @@ Unwrap an algorithm one level. For bare algorithms this is the identity; for
 base_algorithm(alg::HamiltonianAlgorithm) = alg
 base_algorithm(alg::RegularizedIntegrator) = alg.base_alg
 
-# Rewrite a HamiltonianProblem with a new `regularization` field. This is the
-# Phase 3c.1 shim that lets `RegularizedIntegrator` delegate to the existing
-# regularization dispatch code without refactoring hot-path option reads.
-# Phase 3d will drop `prob.regularization` entirely, at which point this
-# helper disappears and the dispatch reads options from the algorithm instead.
-function _with_regularization(prob::HamiltonianProblem, reg::RegularizationOptions)
-    return HamiltonianProblem(
-        prob.system,
-        prob.tspan,
-        prob.q_initial,
-        prob.p_initial;
-        masses = masses(prob),
-        charges = charges(prob),
-        c = speed_of_light(prob),
-        dt = prob.dt,
-        convergence_tolerance = prob.convergence_tolerance,
-        maximum_iterations = prob.maximum_iterations,
-        regularization = reg,
-        zollner = prob.zollner,
-    )
+@inline function _step_core!(
+    integrator::HamiltonianIntegrator,
+    ::RegularizedIntegrator,
+    dt_step::Float64,
+)
+    _step_regularized_dispatch!(integrator, dt_step)
+    return nothing
 end
 
-function CommonSolve.init(
-    prob::HamiltonianProblem,
-    alg::RegularizedIntegrator;
-    callbacks = (),
+function _allocate_cache(prob::HamiltonianProblem, alg::RegularizedIntegrator)
+    buffers = SymmetricProjectionBuffers(prob, alg.options)
+    rb = buffers.regularization_buffers
+    if rb.backend_fallback && alg.options.warn_on_fallback
+        @warn "RegularizationOptions(backend=:lifted_pair) is currently supported only for 2D; falling back to :adaptive_cartesian for $(prob.system.dims)D"
+    end
+    return buffers
+end
+
+function _resolve_callbacks(
+    ::HamiltonianProblem,
+    alg::RegularizedIntegrator,
+    cbs,
 )
-    effective_prob = _with_regularization(prob, alg.options)
-    return CommonSolve.init(effective_prob, alg.base_alg; callbacks = callbacks)
+    user = _normalise_callbacks(cbs)
+    bounce_r = alg.options.collision_bounce_radius
+    if bounce_r > 0 && !any(c -> c isa CollisionBounce, user)
+        return (CollisionBounce(bounce_r), user...)
+    end
+    return user
 end

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -639,7 +639,7 @@ end
 )
     system = prob.system
     ms = masses(prob)
-    g_floor = prob.regularization.g_floor
+    g_floor = rb.options.g_floor
 
     prev_u1 = rb.lc_u[1]
     prev_u2 = rb.lc_u[2]
@@ -757,7 +757,7 @@ end
         integrator.t,
         dt_step,
         integrator.prob,
-        integrator.alg,
+        base_algorithm(integrator.alg),
         integrator.buffers,
     )
 
@@ -796,13 +796,11 @@ end
     ::SymmetricProjectionIntegrator,
     dt_step::Float64,
 )
-    if integrator.prob.regularization.enabled
-        _step_regularized_dispatch!(integrator, dt_step)
-    else
-        _step_unregularized!(integrator, dt_step)
-    end
+    _step_unregularized!(integrator, dt_step)
     return nothing
 end
+# `_step_core!(::RegularizedIntegrator, ...)` lives in integrators/regularized.jl
+# because the type is defined there.
 
 @inline function _step_regularized_pair_adaptive!(
     integrator::HamiltonianIntegrator,
@@ -816,7 +814,7 @@ end
     i = rb.active_anchor_i
     j = rb.active_anchor_j
 
-    reg = prob.regularization
+    reg = rb.options
     constraint_tolerance = reg.constraint_tolerance
     substeps = Int(ceil(rb.r_on / max(min_distance, reg.g_floor)))
     substeps = clamp(substeps, 1, reg.max_substeps)
@@ -865,7 +863,7 @@ end
             t_sub,
             dt_sub,
             prob,
-            integrator.alg,
+            base_algorithm(integrator.alg),
             integrator.buffers,
         )
         t_sub += dt_sub
@@ -897,7 +895,7 @@ end
 
     _set_pair_params!(rb, prob, i, j)
 
-    reg = prob.regularization
+    reg = rb.options
     g_floor = reg.g_floor
     max_sub = reg.max_substeps
 
@@ -957,7 +955,7 @@ end
 )
     prob = integrator.prob
     rb = integrator.buffers.regularization_buffers
-    reg = prob.regularization
+    reg = rb.options
     constraint_tolerance = reg.constraint_tolerance
 
     omega = _component_omega(rb)
@@ -997,7 +995,7 @@ end
             t_sub,
             dt_sub,
             prob,
-            integrator.alg,
+            base_algorithm(integrator.alg),
             integrator.buffers,
         )
         t_sub += dt_sub
@@ -1020,9 +1018,8 @@ end
     integrator::HamiltonianIntegrator,
     dt_step::Float64,
 )
-    prob = integrator.prob
-    reg = prob.regularization
     rb = integrator.buffers.regularization_buffers
+    reg = rb.options
     diagnostics = integrator.diagnostics
 
     was_active = rb.is_active
@@ -1095,13 +1092,10 @@ function _allocate_cache(::HamiltonianProblem, alg::HamiltonianAlgorithm)
 end
 
 function _allocate_cache(prob::HamiltonianProblem, ::SymmetricProjectionIntegrator)
-    buffers = SymmetricProjectionBuffers(prob)
-    rb = buffers.regularization_buffers
-    if prob.regularization.enabled && rb.backend_fallback && prob.regularization.warn_on_fallback
-        @warn "RegularizationOptions(backend=:lifted_pair) is currently supported only for 2D; falling back to :adaptive_cartesian for $(prob.system.dims)D"
-    end
-    return buffers
+    return SymmetricProjectionBuffers(prob, RegularizationOptions())
 end
+# `_allocate_cache(::HamiltonianProblem, ::RegularizedIntegrator)` lives in
+# integrators/regularized.jl because the type is defined there.
 
 """
     init(prob::HamiltonianProblem,
@@ -1118,9 +1112,9 @@ or pass it directly to `solve!`.
 - `callbacks`: a single [`HamiltonianCallback`](@ref) or an iterable of them.
   Invoked pre-/post-step around each macro-step.
 
-If `prob.regularization.collision_bounce_radius > 0` and no `CollisionBounce`
-is present in `callbacks`, a matching one is synthesised automatically so
-the legacy problem-level kwarg keeps working.
+If `alg` is a `RegularizedIntegrator` with `collision_bounce_radius > 0` and
+no `CollisionBounce` is present in `callbacks`, a matching one is synthesised
+automatically so the legacy kwarg keeps working.
 
 # Returns
 - `HamiltonianIntegrator` at `t = prob.tspan[1]` with `step_count = 0`.
@@ -1133,7 +1127,7 @@ function CommonSolve.init(
     degrees_of_freedom = prob.system.degrees_of_freedom
 
     buffers = _allocate_cache(prob, alg)
-    cb_tuple = _resolve_callbacks(prob, callbacks)
+    cb_tuple = _resolve_callbacks(prob, alg, callbacks)
 
     n_steps = Int(ceil((prob.tspan[2] - prob.tspan[1]) / prob.dt))
     t_history = Vector{Float64}(undef, n_steps + 1)
@@ -1144,10 +1138,11 @@ function CommonSolve.init(
     q_history[1] .= prob.q_initial
     p_history[1] .= prob.p_initial
 
-    requested_backend = prob.regularization.enabled ? prob.regularization.backend : REG_BACKEND_DISABLED
+    reg_opts = buffers.regularization_buffers.options
+    requested_backend = reg_opts.enabled ? reg_opts.backend : REG_BACKEND_DISABLED
     used_backend = REG_BACKEND_DISABLED
     diagnostics =
-        RegularizationDiagnostics(prob.regularization.enabled, n_steps, requested_backend, used_backend)
+        RegularizationDiagnostics(reg_opts.enabled, n_steps, requested_backend, used_backend)
 
     HamiltonianIntegrator(
         prob,
@@ -1166,18 +1161,16 @@ function CommonSolve.init(
     )
 end
 
-# Merge user-supplied callbacks with the legacy bridge derived from
-# `prob.regularization.collision_bounce_radius`. When the radius is > 0 and
-# no `CollisionBounce` was supplied explicitly, synthesise one so existing
-# code that sets the radius on RegularizationOptions continues to fire the
-# bounce.
-function _resolve_callbacks(prob::HamiltonianProblem, cbs)
-    user = _normalise_callbacks(cbs)
-    bounce_r = prob.regularization.collision_bounce_radius
-    if bounce_r > 0 && !any(c -> c isa CollisionBounce, user)
-        return (CollisionBounce(bounce_r), user...)
-    end
-    return user
+# Merge user-supplied callbacks with algorithm-synthesised ones. Base version
+# just normalises; the `RegularizedIntegrator` method in
+# integrators/regularized.jl adds a `CollisionBounce` when
+# `collision_bounce_radius > 0` and none was supplied explicitly.
+function _resolve_callbacks(
+    ::HamiltonianProblem,
+    ::HamiltonianAlgorithm,
+    cbs,
+)
+    return _normalise_callbacks(cbs)
 end
 
 # Pre-step collision bounce: for each pair closer than bounce_r,
@@ -1207,8 +1200,9 @@ end
 Advance the integrator by one macro time step `prob.dt`.
 
 Dispatches to the regularized or plain Cartesian integration path based on
-current particle separations and `prob.regularization` settings. The final
-step is automatically shortened to land exactly on `prob.tspan[2]`.
+the algorithm type (`RegularizedIntegrator` vs `SymmetricProjectionIntegrator`)
+and current particle separations. The final step is automatically shortened
+to land exactly on `prob.tspan[2]`.
 
 # Returns
 - `true` if more steps remain, `false` when integration is complete.

--- a/src/types.jl
+++ b/src/types.jl
@@ -298,6 +298,8 @@ mutable struct RegularizationBuffers
     effective_backend::Symbol
     backend_fallback::Bool
 
+    options::RegularizationOptions
+
     chain_order::Vector{Int}
     chain_used::Vector{Bool}
 
@@ -348,6 +350,7 @@ mutable struct RegularizationBuffers
         r_off::Float64,
         effective_backend::Symbol,
         backend_fallback::Bool,
+        options::RegularizationOptions,
     )
         n_pairs = n_particles * (n_particles - 1) ÷ 2
         pair_i = Vector{Int}(undef, n_pairs)
@@ -384,6 +387,7 @@ mutable struct RegularizationBuffers
             r_off,
             effective_backend,
             backend_fallback,
+            options,
             Vector{Int}(undef, n_particles),
             Vector{Bool}(undef, n_particles),
             Vector{Float64}(undef, max(dims, 3)),
@@ -444,10 +448,11 @@ and solver/regularization options into a single immutable structure.
 - `dt`: Fixed macro time step (positive).
 - `convergence_tolerance=1e-13`: Fixed-point convergence threshold for projection.
 - `maximum_iterations=100`: Maximum projection iterations per step.
-- `regularization=RegularizationOptions()`: Close-encounter regularization options.
-  See `RegularizationOptions` for all available fields.
 - `zollner=ZollnerOptions()`: Zöllner electrogravitational extension options.
   See `ZollnerOptions` for all available fields.
+
+Regularization options moved to [`RegularizedIntegrator`](@ref); pass them via
+`solve(prob, RegularizedIntegrator(SymmetricProjectionIntegrator(); ...))`.
 
 # Fields
 - `system::HamiltonianSystem`: Compiled Hamiltonian system.
@@ -458,7 +463,6 @@ and solver/regularization options into a single immutable structure.
 - `dt::Float64`: Fixed step size.
 - `convergence_tolerance::Float64`: Projection convergence threshold.
 - `maximum_iterations::Int`: Maximum projection iterations per step.
-- `regularization::RegularizationOptions`: Regularization configuration.
 - `zollner::ZollnerOptions`: Zöllner extension configuration.
 """
 struct HamiltonianProblem
@@ -470,7 +474,6 @@ struct HamiltonianProblem
     dt::Float64
     convergence_tolerance::Float64
     maximum_iterations::Int
-    regularization::RegularizationOptions
     zollner::ZollnerOptions
 
     function HamiltonianProblem(
@@ -484,7 +487,6 @@ struct HamiltonianProblem
         dt::Real,
         convergence_tolerance::Real = 1e-13,
         maximum_iterations::Integer = 100,
-        regularization::RegularizationOptions = RegularizationOptions(),
         zollner::ZollnerOptions = ZollnerOptions(),
     )
         n_particles = system.n_particles
@@ -516,7 +518,6 @@ struct HamiltonianProblem
             Float64(dt),
             Float64(convergence_tolerance),
             Int(maximum_iterations),
-            regularization,
             zollner,
         )
     end
@@ -530,7 +531,6 @@ end
     speed_of_light(prob::HamiltonianProblem) -> Float64
     kappas(prob::HamiltonianProblem) -> AbstractVector{Float64}
     params(prob::HamiltonianProblem) -> Vector{Float64}
-    regularization(prob::HamiltonianProblem) -> RegularizationOptions
     zollner(prob::HamiltonianProblem) -> ZollnerOptions
 
 Read-only accessors. `masses`, `charges`, and `kappas` return views into the
@@ -545,7 +545,6 @@ charges(prob::HamiltonianProblem) =
 speed_of_light(prob::HamiltonianProblem) = prob.params[2*n_particles(prob)+1]
 kappas(prob::HamiltonianProblem) = @view prob.params[2*n_particles(prob)+2:end]
 params(prob::HamiltonianProblem) = prob.params
-regularization(prob::HamiltonianProblem) = prob.regularization
 zollner(prob::HamiltonianProblem) = prob.zollner
 
 """
@@ -652,7 +651,10 @@ mutable struct SymmetricProjectionBuffers
     diff_buffer::Vector{Float64}
     regularization_buffers::RegularizationBuffers
 
-    function SymmetricProjectionBuffers(prob::HamiltonianProblem)
+    function SymmetricProjectionBuffers(
+        prob::HamiltonianProblem,
+        reg_options::RegularizationOptions,
+    )
         d = prob.system.degrees_of_freedom
         n_particles = prob.system.n_particles
         dims = prob.system.dims
@@ -671,7 +673,6 @@ mutable struct SymmetricProjectionBuffers
             min_pair_distance = 1.0
         end
 
-        reg_options = prob.regularization
         r_on = isnothing(reg_options.r_on) ? (reg_options.r_on_factor * min_pair_distance) : reg_options.r_on
         r_off = isnothing(reg_options.r_off) ? (reg_options.r_off_factor * min_pair_distance) : reg_options.r_off
         r_on_value = Float64(max(r_on, reg_options.g_floor))
@@ -685,6 +686,7 @@ mutable struct SymmetricProjectionBuffers
             r_off_value,
             effective_backend,
             backend_fallback,
+            reg_options,
         )
 
         new(

--- a/test/regression/capture.jl
+++ b/test/regression/capture.jl
@@ -22,7 +22,7 @@
 # fixtures during `Pkg.test()` without polluting the package's runtime deps.
 
 using WeberElectrodynamics
-using WeberElectrodynamics: SymmetricProjectionIntegrator
+using WeberElectrodynamics: SymmetricProjectionIntegrator, RegularizedIntegrator
 using JLD2
 using Dates
 using Symbolics: pkgversion
@@ -136,8 +136,9 @@ function fixture_twobody_ellipse()
         system, tspan, q_initial, p_initial;
         masses = [m1, m2], charges = [q1, q2], c = c, dt = dt,
     )
-    sol = solve(prob, SymmetricProjectionIntegrator())
-    return prob, sol, "twobody_ellipse",
+    alg = SymmetricProjectionIntegrator()
+    sol = solve(prob, alg)
+    return prob, alg, sol, "twobody_ellipse",
         "2-body unregularized bound elliptic orbit (finite c, mild eccentricity)"
 end
 
@@ -156,8 +157,9 @@ function fixture_threebody_mixed()
         system, tspan, q_initial, p_initial;
         masses = masses, charges = charges, c = c, dt = dt,
     )
-    sol = solve(prob, SymmetricProjectionIntegrator())
-    return prob, sol, "threebody_mixed",
+    alg = SymmetricProjectionIntegrator()
+    sol = solve(prob, alg)
+    return prob, alg, sol, "threebody_mixed",
         "3-body unregularized mixed-charge system starting from rest"
 end
 
@@ -180,8 +182,13 @@ function fixture_close_approach_lifted()
     tspan = (0.0, 8.0)
     dt = 2e-3
 
-    reg = RegularizationOptions(
-        enabled = true,
+    system = HamiltonianSystem(2, 2)
+    prob = HamiltonianProblem(
+        system, tspan, q_initial, p_initial;
+        masses = [m1, m2], charges = [q1, q2], c = c, dt = dt,
+    )
+    alg = RegularizedIntegrator(
+        SymmetricProjectionIntegrator();
         backend = :lifted_pair,
         r_on_factor = 0.3,
         r_off_factor = 0.45,
@@ -189,15 +196,8 @@ function fixture_close_approach_lifted()
         constraint_tolerance = 1e-12,
         warn_on_fallback = false,
     )
-
-    system = HamiltonianSystem(2, 2)
-    prob = HamiltonianProblem(
-        system, tspan, q_initial, p_initial;
-        masses = [m1, m2], charges = [q1, q2], c = c, dt = dt,
-        regularization = reg,
-    )
-    sol = solve(prob, SymmetricProjectionIntegrator())
-    return prob, sol, "close_approach_lifted",
+    sol = solve(prob, alg)
+    return prob, alg, sol, "close_approach_lifted",
         "2-body close approach with :lifted_pair Levi-Civita regularization"
 end
 
@@ -221,25 +221,24 @@ function fixture_zollner_offmatch()
     tspan = (0.0, 5.0)
     dt = 1e-3
 
-    reg = RegularizationOptions(
-        enabled = true,
-        backend = :adaptive_cartesian,
-        r_on_factor = 0.4,
-        r_off_factor = 0.6,
-        max_substeps = 512,
-        warn_on_fallback = false,
-    )
     zol = ZollnerOptions(enabled = true, a = 0.05)
 
     system = HamiltonianSystem(2, 2)
     prob = HamiltonianProblem(
         system, tspan, q_initial, p_initial;
         masses = [m1, m2], charges = [q1, q2], c = c, dt = dt,
-        regularization = reg,
         zollner = zol,
     )
-    sol = solve(prob, SymmetricProjectionIntegrator())
-    return prob, sol, "zollner_offmatch",
+    alg = RegularizedIntegrator(
+        SymmetricProjectionIntegrator();
+        backend = :adaptive_cartesian,
+        r_on_factor = 0.4,
+        r_off_factor = 0.6,
+        max_substeps = 512,
+        warn_on_fallback = false,
+    )
+    sol = solve(prob, alg)
+    return prob, alg, sol, "zollner_offmatch",
         "2-body Zöllner off-match (a≠0) with adaptive-Cartesian regularization"
 end
 
@@ -247,7 +246,20 @@ end
 # Write JLD2 fixture file
 # ---------------------------------------------------------------------------
 
-function save_fixture(prob::HamiltonianProblem, sol::HamiltonianSolution, name::String, desc::String)
+function _alg_reg_opts(::SymmetricProjectionIntegrator)
+    RegularizationOptions()
+end
+function _alg_reg_opts(alg::RegularizedIntegrator)
+    alg.options
+end
+
+function save_fixture(
+    prob::HamiltonianProblem,
+    alg,
+    sol::HamiltonianSolution,
+    name::String,
+    desc::String,
+)
     setup = Dict{String,Any}(
         "n_particles" => prob.system.n_particles,
         "dims" => prob.system.dims,
@@ -262,7 +274,7 @@ function save_fixture(prob::HamiltonianProblem, sol::HamiltonianSolution, name::
         "dt" => prob.dt,
         "convergence_tolerance" => prob.convergence_tolerance,
         "maximum_iterations" => prob.maximum_iterations,
-        "regularization" => reg_opts_to_dict(prob.regularization),
+        "regularization" => reg_opts_to_dict(_alg_reg_opts(alg)),
         "zollner" => zollner_opts_to_dict(prob.zollner),
     )
 
@@ -304,10 +316,10 @@ function main()
         name_guess = string(nameof(builder))
         print("Building $name_guess ... ")
         t0 = time()
-        prob, sol, name, desc = builder()
+        prob, alg, sol, name, desc = builder()
         elapsed = time() - t0
         println("solve=$(round(elapsed; digits=2))s")
-        save_fixture(prob, sol, name, desc)
+        save_fixture(prob, alg, sol, name, desc)
         if sol.retcode != :Success
             error("Fixture $name produced retcode=$(sol.retcode); aborting.")
         end

--- a/test/regression/validate.jl
+++ b/test/regression/validate.jl
@@ -20,7 +20,7 @@
 #   include("test/regression/validate.jl"); validate_all()
 
 using WeberElectrodynamics
-using WeberElectrodynamics: SymmetricProjectionIntegrator
+using WeberElectrodynamics: SymmetricProjectionIntegrator, RegularizedIntegrator
 using JLD2
 using Printf
 
@@ -37,11 +37,12 @@ const FIXTURES = [
 # bug, not a tolerance issue.
 const TOLERANCE = 1e-12
 
-# Reconstruct RegularizationOptions from a fixture setup dict.
-function _rebuild_reg_options(d::Dict{String,Any})
-    backend_sym = Symbol(d["backend"])
-    RegularizationOptions(
-        enabled = d["enabled"],
+# Build a RegularizedIntegrator wrapper from a fixture's regularization dict.
+# Returns `nothing` when the fixture was unregularized.
+function _rebuild_algorithm(d::Dict{String,Any})
+    d["enabled"] || return SymmetricProjectionIntegrator()
+    return RegularizedIntegrator(
+        SymmetricProjectionIntegrator();
         r_on = d["r_on"],
         r_off = d["r_off"],
         r_on_factor = d["r_on_factor"],
@@ -50,7 +51,7 @@ function _rebuild_reg_options(d::Dict{String,Any})
         constraint_tolerance = d["constraint_tolerance"],
         g_floor = d["g_floor"],
         chain_enabled = d["chain_enabled"],
-        backend = backend_sym,
+        backend = Symbol(d["backend"]),
         warn_on_fallback = d["warn_on_fallback"],
         collision_bounce_radius = d["collision_bounce_radius"],
     )
@@ -60,22 +61,21 @@ function _rebuild_zollner_options(d::Dict{String,Any})
     ZollnerOptions(enabled = d["enabled"], a = d["a"])
 end
 
-# Rebuild the HamiltonianProblem corresponding to a fixture.
+# Rebuild the HamiltonianProblem + algorithm corresponding to a fixture.
 #
 # This function is the single point that must be updated each time the public
-# problem-building API changes (e.g. Phase 1 of the refactor will rewrite it
-# to use HamiltonianSystem + weber_term + HamiltonianProblem).
+# problem-building API changes.
 function rebuild_problem(setup::Dict{String,Any})
     n_particles = setup["n_particles"]::Int
     dims = setup["dims"]::Int
     system = HamiltonianSystem(n_particles, dims)
 
-    reg = _rebuild_reg_options(setup["regularization"])
+    alg = _rebuild_algorithm(setup["regularization"])
     zol = _rebuild_zollner_options(setup["zollner"])
 
     tspan = Tuple(setup["tspan"]::Vector{Float64})
 
-    return HamiltonianProblem(
+    prob = HamiltonianProblem(
         system,
         tspan,
         setup["q_initial"]::Vector{Float64},
@@ -86,9 +86,9 @@ function rebuild_problem(setup::Dict{String,Any})
         dt = setup["dt"]::Float64,
         convergence_tolerance = setup["convergence_tolerance"]::Float64,
         maximum_iterations = setup["maximum_iterations"]::Int,
-        regularization = reg,
         zollner = zol,
     )
+    return prob, alg
 end
 
 # Compare a fresh solution against a captured trajectory.
@@ -128,8 +128,8 @@ function validate_fixture(name::String)
         )
     end
 
-    prob = rebuild_problem(fixture["setup"])
-    sol = solve(prob, SymmetricProjectionIntegrator())
+    prob, alg = rebuild_problem(fixture["setup"])
+    sol = solve(prob, alg)
     max_t, max_q, max_p, ok_ret = compare_trajectory(sol, fixture["trajectory"])
 
     pass = max_q ≤ TOLERANCE && max_p ≤ TOLERANCE && max_t ≤ TOLERANCE && ok_ret

--- a/test/test_accessors.jl
+++ b/test/test_accessors.jl
@@ -45,8 +45,7 @@
         @test κ ≈ [1.1, 1.0, 1.1]
     end
 
-    @testset "regularization/zollner options accessors" begin
-        reg = RegularizationOptions(enabled = true, r_on_factor = 0.2, r_off_factor = 0.3)
+    @testset "zollner options accessor" begin
         zopts = ZollnerOptions(enabled = true, a = 0.05)
         prob = HamiltonianProblem(
             sys, (0.0, 1.0), zeros(6), zeros(6);
@@ -54,10 +53,8 @@
             charges = [1.0, -1.0, 1.0],
             c = 10.0,
             dt = 0.01,
-            regularization = reg,
             zollner = zopts,
         )
-        @test regularization(prob) === reg
         @test zollner(prob) === zopts
     end
 end

--- a/test/test_callbacks.jl
+++ b/test/test_callbacks.jl
@@ -34,11 +34,12 @@
         @test integrator.callbacks[1] === cb
     end
 
-    # The CollisionBounce callback must produce trajectories bit-exactly
-    # identical to the legacy `collision_bounce_radius` kwarg on the problem.
-    # Sub-critical like-charge head-on oscillation: bounce is active every
-    # half-period, so every step exercises the reflection branch.
-    @testset "equivalence: callback vs prob.regularization.collision_bounce_radius" begin
+    # The CollisionBounce callback synthesised from `collision_bounce_radius`
+    # on a `RegularizedIntegrator` must produce trajectories bit-exactly identical
+    # to an explicit `CollisionBounce` callback. Sub-critical like-charge head-on
+    # oscillation: bounce is active every half-period, so every step exercises
+    # the reflection branch.
+    @testset "equivalence: collision_bounce_radius synthesises CollisionBounce" begin
         m1 = m2 = 1.0
         q1 = q2 = 1.0
         c = 4.0
@@ -51,23 +52,7 @@
         q_init = [r0 / 2, 0.0, -r0 / 2, 0.0]
         p_init = [0.0, 0.0, 0.0, 0.0]
 
-        prob_legacy = HamiltonianProblem(
-            sys,
-            (0.0, 3 * T),
-            q_init,
-            p_init;
-            masses = [m1, m2],
-            charges = [q1, q2],
-            c = c,
-            dt = T / 500,
-            regularization = RegularizationOptions(
-                enabled = false,
-                collision_bounce_radius = 0.01,
-            ),
-        )
-        sol_legacy = solve(prob_legacy)
-
-        prob_callback = HamiltonianProblem(
+        prob = HamiltonianProblem(
             sys,
             (0.0, 3 * T),
             q_init,
@@ -77,27 +62,39 @@
             c = c,
             dt = T / 500,
         )
-        sol_callback = solve(
-            prob_callback,
+        alg_synth = RegularizedIntegrator(
             SymmetricProjectionIntegrator();
-            callbacks = CollisionBounce(0.01),
+            backend = :adaptive_cartesian,
+            warn_on_fallback = false,
+            r_on = 0.001,
+            r_off = 0.002,
+            collision_bounce_radius = 0.01,
         )
+        alg_plain = RegularizedIntegrator(
+            SymmetricProjectionIntegrator();
+            backend = :adaptive_cartesian,
+            warn_on_fallback = false,
+            r_on = 0.001,
+            r_off = 0.002,
+        )
+        sol_synth = solve(prob, alg_synth)
+        sol_explicit = solve(prob, alg_plain; callbacks = CollisionBounce(0.01))
 
-        @test sol_legacy.retcode === sol_callback.retcode
-        @test length(sol_legacy.t) == length(sol_callback.t)
+        @test sol_synth.retcode === sol_explicit.retcode
+        @test length(sol_synth.t) == length(sol_explicit.t)
         max_q = maximum(
-            maximum(abs, sol_legacy.q[i] .- sol_callback.q[i]) for
-            i in eachindex(sol_legacy.q)
+            maximum(abs, sol_synth.q[i] .- sol_explicit.q[i]) for
+            i in eachindex(sol_synth.q)
         )
         max_p = maximum(
-            maximum(abs, sol_legacy.p[i] .- sol_callback.p[i]) for
-            i in eachindex(sol_legacy.p)
+            maximum(abs, sol_synth.p[i] .- sol_explicit.p[i]) for
+            i in eachindex(sol_synth.p)
         )
         @test max_q == 0.0
         @test max_p == 0.0
     end
 
-    @testset "legacy bridge synthesises CollisionBounce when none supplied" begin
+    @testset "RegularizedIntegrator bridge synthesises CollisionBounce" begin
         sys = HamiltonianSystem(2, 2)
         prob = HamiltonianProblem(
             sys, (0.0, 0.05), [1.0, 0.0, -1.0, 0.0], [0.0, 0.1, 0.0, -0.1];
@@ -105,18 +102,20 @@
             charges = [1.0, -1.0],
             c = 100.0,
             dt = 0.01,
-            regularization = RegularizationOptions(
-                enabled = false,
-                collision_bounce_radius = 0.05,
-            ),
         )
-        integrator = init(prob, SymmetricProjectionIntegrator())
+        alg = RegularizedIntegrator(
+            SymmetricProjectionIntegrator();
+            backend = :adaptive_cartesian,
+            warn_on_fallback = false,
+            collision_bounce_radius = 0.05,
+        )
+        integrator = init(prob, alg)
         @test length(integrator.callbacks) == 1
         @test integrator.callbacks[1] isa CollisionBounce
         @test integrator.callbacks[1].radius == 0.05
     end
 
-    @testset "explicit CollisionBounce overrides legacy synthesis" begin
+    @testset "explicit CollisionBounce overrides bridge synthesis" begin
         sys = HamiltonianSystem(2, 2)
         prob = HamiltonianProblem(
             sys, (0.0, 0.05), [1.0, 0.0, -1.0, 0.0], [0.0, 0.1, 0.0, -0.1];
@@ -124,14 +123,15 @@
             charges = [1.0, -1.0],
             c = 100.0,
             dt = 0.01,
-            regularization = RegularizationOptions(
-                enabled = false,
-                collision_bounce_radius = 0.05,
-            ),
+        )
+        alg = RegularizedIntegrator(
+            SymmetricProjectionIntegrator();
+            backend = :adaptive_cartesian,
+            warn_on_fallback = false,
+            collision_bounce_radius = 0.05,
         )
         explicit = CollisionBounce(0.07)
-        integrator =
-            init(prob, SymmetricProjectionIntegrator(); callbacks = explicit)
+        integrator = init(prob, alg; callbacks = explicit)
         @test length(integrator.callbacks) == 1
         @test integrator.callbacks[1] === explicit
     end

--- a/test/test_regularization.jl
+++ b/test/test_regularization.jl
@@ -37,7 +37,7 @@
         end
 
         system = HamiltonianSystem(2, dims)
-        return HamiltonianProblem(
+        prob = HamiltonianProblem(
             system,
             (0.0, t_end),
             q0,
@@ -46,15 +46,20 @@
             charges = charges,
             c = c,
             dt = dt,
-            regularization = RegularizationOptions(
-                enabled = regularization_enabled,
+        )
+        alg = if regularization_enabled
+            RegularizedIntegrator(
+                SymmetricProjectionIntegrator();
                 backend = backend,
                 warn_on_fallback = warn_on_fallback,
                 r_on = r_on,
                 r_off = r_off,
                 max_substeps = max_substeps,
-            ),
-        )
+            )
+        else
+            SymmetricProjectionIntegrator()
+        end
+        return prob, alg
     end
 
     state_error(sol_a::HamiltonianSolution, sol_b::HamiltonianSolution) =
@@ -65,36 +70,16 @@
         q0_2d = [-1.0, 0.0, 1.0, 0.0]
         p0_2d = [0.0, -0.05, 0.0, 0.05]
 
-        prob_valid = HamiltonianProblem(
-            sys2,
-            (0.0, 0.1),
-            q0_2d,
-            p0_2d;
-            masses = [1.0, 0.5],
-            charges = [0.1, -0.1],
-            c = 4.0,
-            dt = 0.001,
-            regularization = RegularizationOptions(
-                enabled = true,
-                backend = :adaptive_cartesian,
-                warn_on_fallback = false,
-            ),
+        alg_valid = RegularizedIntegrator(
+            SymmetricProjectionIntegrator();
+            backend = :adaptive_cartesian,
+            warn_on_fallback = false,
         )
-        @test prob_valid.regularization.backend == WeberElectrodynamics.REG_BACKEND_ADAPTIVE
+        @test alg_valid.options.backend == WeberElectrodynamics.REG_BACKEND_ADAPTIVE
 
-        @test_throws AssertionError HamiltonianProblem(
-            sys2,
-            (0.0, 0.1),
-            q0_2d,
-            p0_2d;
-            masses = [1.0, 0.5],
-            charges = [0.1, -0.1],
-            c = 4.0,
-            dt = 0.001,
-            regularization = RegularizationOptions(
-                enabled = true,
-                backend = :invalid_backend,
-            ),
+        @test_throws AssertionError RegularizedIntegrator(
+            SymmetricProjectionIntegrator();
+            backend = :invalid_backend,
         )
 
         sys1 = HamiltonianSystem(2, 1)
@@ -110,15 +95,15 @@
             charges = [0.2, -0.2],
             c = 4.0,
             dt = 0.001,
-            regularization = RegularizationOptions(
-                enabled = true,
-                backend = :lifted_pair,
-                warn_on_fallback = false,
-                r_on = 0.2,
-                r_off = 0.26,
-            ),
         )
-        int_fb = init(prob_fb)
+        alg_fb = RegularizedIntegrator(
+            SymmetricProjectionIntegrator();
+            backend = :lifted_pair,
+            warn_on_fallback = false,
+            r_on = 0.2,
+            r_off = 0.26,
+        )
+        int_fb = init(prob_fb, alg_fb)
         rb_fb = int_fb.buffers.regularization_buffers
         @test rb_fb.effective_backend == WeberElectrodynamics.REG_BACKEND_ADAPTIVE
         @test rb_fb.backend_fallback
@@ -128,24 +113,14 @@
         @test int_fb.diagnostics.lifted_pair_steps == 0
         @test int_fb.diagnostics.backend_fallback_steps == 1
 
-        prob_warn = HamiltonianProblem(
-            sys1,
-            (0.0, 0.01),
-            q0_1d,
-            p0_1d;
-            masses = [1.0, 1.0],
-            charges = [0.2, -0.2],
-            c = 4.0,
-            dt = 0.001,
-            regularization = RegularizationOptions(
-                enabled = true,
-                backend = :lifted_pair,
-                warn_on_fallback = true,
-                r_on = 0.2,
-                r_off = 0.26,
-            ),
+        alg_warn = RegularizedIntegrator(
+            SymmetricProjectionIntegrator();
+            backend = :lifted_pair,
+            warn_on_fallback = true,
+            r_on = 0.2,
+            r_off = 0.26,
         )
-        @test_logs (:warn, r"falling back to :adaptive_cartesian") init(prob_warn)
+        @test_logs (:warn, r"falling back to :adaptive_cartesian") init(prob_fb, alg_warn)
     end
 
     @testset "3D lifted pair fallback to adaptive_cartesian" begin
@@ -164,15 +139,15 @@
             charges = [0.1, -0.1],
             c = 4.0,
             dt = 0.001,
-            regularization = RegularizationOptions(
-                enabled = true,
-                backend = :lifted_pair,
-                warn_on_fallback = false,
-                r_on = 0.2,
-                r_off = 0.3,
-            ),
         )
-        int_3d = init(prob_3d)
+        alg_3d = RegularizedIntegrator(
+            SymmetricProjectionIntegrator();
+            backend = :lifted_pair,
+            warn_on_fallback = false,
+            r_on = 0.2,
+            r_off = 0.3,
+        )
+        int_3d = init(prob_3d, alg_3d)
         rb_3d = int_3d.buffers.regularization_buffers
         @test rb_3d.effective_backend == WeberElectrodynamics.REG_BACKEND_ADAPTIVE
         @test rb_3d.backend_fallback
@@ -181,29 +156,20 @@
         @test int_3d.diagnostics.backend_fallback_steps == 1
         @test int_3d.diagnostics.lifted_pair_steps == 0
 
-        @test_logs (:warn, r"falling back to :adaptive_cartesian") init(HamiltonianProblem(
-            sys3,
-            (0.0, 0.01),
-            q0_3d,
-            p0_3d;
-            masses = [1.0, 0.5],
-            charges = [0.1, -0.1],
-            c = 4.0,
-            dt = 0.001,
-            regularization = RegularizationOptions(
-                enabled = true,
-                backend = :lifted_pair,
-                warn_on_fallback = true,
-                r_on = 0.2,
-                r_off = 0.3,
-            ),
-        ))
+        alg_3d_warn = RegularizedIntegrator(
+            SymmetricProjectionIntegrator();
+            backend = :lifted_pair,
+            warn_on_fallback = true,
+            r_on = 0.2,
+            r_off = 0.3,
+        )
+        @test_logs (:warn, r"falling back to :adaptive_cartesian") init(prob_3d, alg_3d_warn)
     end
 
     @testset "Transform identities" begin
         @testset "Levi-Civita" begin
             Random.seed!(42)
-            rb = WeberElectrodynamics.RegularizationBuffers(2, 2, 4, 0.1, 0.2, :lifted_pair, false)
+            rb = WeberElectrodynamics.RegularizationBuffers(2, 2, 4, 0.1, 0.2, :lifted_pair, false, RegularizationOptions())
             q_rel = zeros(2)
             p_rel = zeros(2)
 
@@ -233,7 +199,7 @@
         end
 
         @testset "KS" begin
-            rb = WeberElectrodynamics.RegularizationBuffers(2, 3, 6, 0.1, 0.2, :adaptive_cartesian, false)
+            rb = WeberElectrodynamics.RegularizationBuffers(2, 3, 6, 0.1, 0.2, :adaptive_cartesian, false, RegularizationOptions())
             J = rb.ks_J
 
             for _ = 1:32
@@ -266,7 +232,7 @@
     end
 
     @testset "Switching and hysteresis" begin
-        rb = WeberElectrodynamics.RegularizationBuffers(3, 2, 6, 0.2, 0.3, :adaptive_cartesian, false)
+        rb = WeberElectrodynamics.RegularizationBuffers(3, 2, 6, 0.2, 0.3, :adaptive_cartesian, false, RegularizationOptions())
 
         q_activate = [-0.09, 0.0, 0.09, 0.0, 0.8, 0.0]
         active, mode, _ = WeberElectrodynamics._detect_regularization_component!(rb, q_activate, true)
@@ -302,7 +268,7 @@
     end
 
     @testset "Chain-disabled overlap fallback" begin
-        rb = WeberElectrodynamics.RegularizationBuffers(3, 2, 6, 0.2, 0.3, :adaptive_cartesian, false)
+        rb = WeberElectrodynamics.RegularizationBuffers(3, 2, 6, 0.2, 0.3, :adaptive_cartesian, false, RegularizationOptions())
         q_overlap = [-0.09, 0.0, 0.09, 0.0, 0.2, 0.0]
         active, mode, _ = WeberElectrodynamics._detect_regularization_component!(rb, q_overlap, false)
         @test active
@@ -321,16 +287,16 @@
             charges = [0.1, -0.2, 0.1],
             c = 4.0,
             dt = 0.001,
-            regularization = RegularizationOptions(
-                enabled = true,
-                backend = :adaptive_cartesian,
-                warn_on_fallback = false,
-                r_on = 0.2,
-                r_off = 0.3,
-                chain_enabled = false,
-            ),
         )
-        sol = solve(prob)
+        alg = RegularizedIntegrator(
+            SymmetricProjectionIntegrator();
+            backend = :adaptive_cartesian,
+            warn_on_fallback = false,
+            r_on = 0.2,
+            r_off = 0.3,
+            chain_enabled = false,
+        )
+        sol = solve(prob, alg)
         @test sol.retcode == :Success
         @test sol.regularization.pair_steps == 0
         @test sol.regularization.chain_steps == 0
@@ -338,7 +304,7 @@
     end
 
     @testset "Pair mode correctness (2D lifted)" begin
-        coarse_cart = make_orbit_problem(2;
+        prob_cart, alg_cart = make_orbit_problem(2;
             dt = 0.004,
             t_end = 3.0,
             v_scale = 0.2,
@@ -347,7 +313,7 @@
             r_on = 0.6,
             r_off = 0.9,
         )
-        coarse_adaptive = make_orbit_problem(2;
+        prob_adaptive, alg_adaptive = make_orbit_problem(2;
             dt = 0.004,
             t_end = 3.0,
             v_scale = 0.2,
@@ -356,7 +322,7 @@
             r_on = 0.6,
             r_off = 0.9,
         )
-        coarse_lifted = make_orbit_problem(2;
+        prob_lifted, alg_lifted = make_orbit_problem(2;
             dt = 0.004,
             t_end = 3.0,
             v_scale = 0.2,
@@ -365,7 +331,7 @@
             r_on = 0.6,
             r_off = 0.9,
         )
-        fine_ref = make_orbit_problem(2;
+        prob_ref, alg_ref = make_orbit_problem(2;
             dt = 0.001,
             t_end = 3.0,
             v_scale = 0.2,
@@ -375,10 +341,10 @@
             r_off = 0.9,
         )
 
-        sol_cart = solve(coarse_cart)
-        sol_adaptive = solve(coarse_adaptive)
-        sol_lifted = solve(coarse_lifted)
-        sol_ref = solve(fine_ref)
+        sol_cart = solve(prob_cart, alg_cart)
+        sol_adaptive = solve(prob_adaptive, alg_adaptive)
+        sol_lifted = solve(prob_lifted, alg_lifted)
+        sol_ref = solve(prob_ref, alg_ref)
 
         @test sol_cart.retcode == :Success
         @test sol_adaptive.retcode == :Success
@@ -425,13 +391,13 @@
             charges = [q1, q2],
             c = c,
             dt = T_est / 2000,
-            regularization = RegularizationOptions(
-                enabled = false,
-                collision_bounce_radius = 0.01,
-            ),
         )
 
-        sol = solve(prob)
+        sol = solve(
+            prob,
+            SymmetricProjectionIntegrator();
+            callbacks = CollisionBounce(0.01),
+        )
         @test sol.retcode == :Success
 
         # All states finite.
@@ -476,19 +442,19 @@
             charges = [q1, q2],
             c = c,
             dt = T_est / 1000,
-            regularization = RegularizationOptions(
-                enabled = true,
-                backend = :adaptive_cartesian,
-                warn_on_fallback = false,
-                # Set r_on below bounce_r so regularization stays idle;
-                # bounce handles the singularity and the two features coexist.
-                r_on = 0.005,
-                r_off = 0.015,
-                collision_bounce_radius = 0.01,
-            ),
+        )
+        alg = RegularizedIntegrator(
+            SymmetricProjectionIntegrator();
+            backend = :adaptive_cartesian,
+            warn_on_fallback = false,
+            # Set r_on below bounce_r so regularization stays idle;
+            # bounce handles the singularity and the two features coexist.
+            r_on = 0.005,
+            r_off = 0.015,
+            collision_bounce_radius = 0.01,
         )
 
-        sol = solve(prob)
+        sol = solve(prob, alg)
         @test sol.retcode == :Success
         @test all(isfinite, sol.q[end])
         @test all(isfinite, sol.p[end])
@@ -511,18 +477,18 @@
             charges = [0.1, -0.2, 0.1],
             c = 4.0,
             dt = 0.002,
-            regularization = RegularizationOptions(
-                enabled = true,
-                backend = :lifted_pair,
-                warn_on_fallback = false,
-                r_on = 0.28,
-                r_off = 0.39,
-                chain_enabled = true,
-                max_substeps = 256,
-            ),
+        )
+        alg = RegularizedIntegrator(
+            SymmetricProjectionIntegrator();
+            backend = :lifted_pair,
+            warn_on_fallback = false,
+            r_on = 0.28,
+            r_off = 0.39,
+            chain_enabled = true,
+            max_substeps = 256,
         )
 
-        sol = solve(prob)
+        sol = solve(prob, alg)
         @test sol.retcode == :Success
         @test sol.regularization.chain_steps > 0
         @test sol.regularization.lifted_pair_steps == 0
@@ -540,31 +506,23 @@
             dt = 0.001,
         )
 
-        prob_off = HamiltonianProblem(
+        prob_shared = HamiltonianProblem(
             sys,
             (0.0, 0.2),
             q0,
             p0;
             kwargs...,
-            regularization = RegularizationOptions(enabled = false),
         )
-        prob_on = HamiltonianProblem(
-            sys,
-            (0.0, 0.2),
-            q0,
-            p0;
-            kwargs...,
-            regularization = RegularizationOptions(
-                enabled = true,
-                backend = :adaptive_cartesian,
-                warn_on_fallback = false,
-                r_on = 0.05,
-                r_off = 0.08,
-            ),
+        alg_on = RegularizedIntegrator(
+            SymmetricProjectionIntegrator();
+            backend = :adaptive_cartesian,
+            warn_on_fallback = false,
+            r_on = 0.05,
+            r_off = 0.08,
         )
 
-        sol_off = solve(prob_off)
-        sol_on = solve(prob_on)
+        sol_off = solve(prob_shared, SymmetricProjectionIntegrator())
+        sol_on = solve(prob_shared, alg_on)
 
         @test sol_on.regularization.pair_steps == 0
         @test sol_on.regularization.chain_steps == 0
@@ -588,13 +546,13 @@
             charges = [0.0],
             c = 4.0,
             dt = 0.01,
-            regularization = RegularizationOptions(
-                enabled = true,
-                backend = :adaptive_cartesian,
-                warn_on_fallback = false,
-            ),
         )
-        sol = solve(prob)
+        alg = RegularizedIntegrator(
+            SymmetricProjectionIntegrator();
+            backend = :adaptive_cartesian,
+            warn_on_fallback = false,
+        )
+        sol = solve(prob, alg)
         @test sol.retcode == :Success
         @test sol.regularization.pair_steps == 0
         @test sol.regularization.chain_steps == 0
@@ -602,7 +560,7 @@
     end
 
     @testset "Diagnostics validity" begin
-        prob = make_orbit_problem(2;
+        prob, alg = make_orbit_problem(2;
             dt = 0.004,
             t_end = 3.0,
             v_scale = 0.2,
@@ -611,7 +569,7 @@
             r_on = 0.6,
             r_off = 0.9,
         )
-        sol = solve(prob)
+        sol = solve(prob, alg)
         d = sol.regularization
 
         @test d.pair_steps + d.chain_steps + d.unregularized_steps == length(sol) - 1
@@ -638,7 +596,6 @@
             charges = [0.1, -0.1],
             c = 4.0,
             dt = 0.001,
-            regularization = RegularizationOptions(enabled = false),
         )
         int_unreg = init(prob_unreg)
         step!(int_unreg)
@@ -656,16 +613,16 @@
             charges = [0.1, -0.1],
             c = 4.0,
             dt = 0.001,
-            regularization = RegularizationOptions(
-                enabled = true,
-                backend = :lifted_pair,
-                warn_on_fallback = false,
-                r_on = 0.2,
-                r_off = 0.26,
-                max_substeps = 256,
-            ),
         )
-        int_lifted = init(prob_lifted)
+        alg_lifted = RegularizedIntegrator(
+            SymmetricProjectionIntegrator();
+            backend = :lifted_pair,
+            warn_on_fallback = false,
+            r_on = 0.2,
+            r_off = 0.26,
+            max_substeps = 256,
+        )
+        int_lifted = init(prob_lifted, alg_lifted)
         step!(int_lifted)
         @test int_lifted.diagnostics.mode_history[1] == WeberElectrodynamics.REG_MODE_PAIR
         alloc_lifted = @allocated step!(int_lifted)

--- a/test/test_regularized_integrator.jl
+++ b/test/test_regularized_integrator.jl
@@ -1,5 +1,3 @@
-using JLD2
-
 @testset "RegularizedIntegrator wrapper" begin
     @testset "subtyping + unwrap" begin
         base = SymmetricProjectionIntegrator(relaxation = 0.25)
@@ -30,88 +28,5 @@ using JLD2
         @test alg.options.chain_enabled === false
         @test alg.options.warn_on_fallback === false
         @test alg.options.collision_bounce_radius == 0.01
-    end
-
-    # The wrapper must produce trajectories numerically identical to those from
-    # the equivalent prob-level `regularization = ...` kwarg. This verifies the
-    # Phase 3c.1 shim — rewriting `prob.regularization` at init time — preserves
-    # bit-exact output against the existing regularization dispatch code.
-    @testset "equivalence with prob-level regularization" begin
-        fixture_path =
-            joinpath(@__DIR__, "regression", "fixtures", "close_approach_lifted.jld2")
-        fixture = jldopen(fixture_path, "r") do file
-            Dict{String,Any}(
-                "setup" => read(file, "setup"),
-                "trajectory" => read(file, "trajectory"),
-            )
-        end
-        setup = fixture["setup"]
-        reg_dict = setup["regularization"]
-        reg_opts = RegularizationOptions(
-            enabled = reg_dict["enabled"],
-            r_on = reg_dict["r_on"],
-            r_off = reg_dict["r_off"],
-            r_on_factor = reg_dict["r_on_factor"],
-            r_off_factor = reg_dict["r_off_factor"],
-            max_substeps = reg_dict["max_substeps"],
-            constraint_tolerance = reg_dict["constraint_tolerance"],
-            g_floor = reg_dict["g_floor"],
-            chain_enabled = reg_dict["chain_enabled"],
-            backend = Symbol(reg_dict["backend"]),
-            warn_on_fallback = reg_dict["warn_on_fallback"],
-            collision_bounce_radius = reg_dict["collision_bounce_radius"],
-        )
-
-        sys = HamiltonianSystem(setup["n_particles"]::Int, setup["dims"]::Int)
-        base_kwargs = (
-            masses = setup["masses"]::Vector{Float64},
-            charges = setup["charges"]::Vector{Float64},
-            c = setup["c"]::Float64,
-            dt = setup["dt"]::Float64,
-            convergence_tolerance = setup["convergence_tolerance"]::Float64,
-            maximum_iterations = setup["maximum_iterations"]::Int,
-        )
-
-        # Problem A: regularization baked into the problem (existing API).
-        prob_a = HamiltonianProblem(
-            sys,
-            Tuple(setup["tspan"]::Vector{Float64}),
-            setup["q_initial"]::Vector{Float64},
-            setup["p_initial"]::Vector{Float64};
-            base_kwargs...,
-            regularization = reg_opts,
-        )
-        sol_a = solve(prob_a, SymmetricProjectionIntegrator())
-
-        # Problem B: same setup but regularization via the algorithm wrapper.
-        prob_b = HamiltonianProblem(
-            sys,
-            Tuple(setup["tspan"]::Vector{Float64}),
-            setup["q_initial"]::Vector{Float64},
-            setup["p_initial"]::Vector{Float64};
-            base_kwargs...,
-        )
-        alg = WeberElectrodynamics.RegularizedIntegrator(
-            SymmetricProjectionIntegrator();
-            r_on = reg_opts.r_on,
-            r_off = reg_opts.r_off,
-            r_on_factor = reg_opts.r_on_factor,
-            r_off_factor = reg_opts.r_off_factor,
-            max_substeps = reg_opts.max_substeps,
-            constraint_tolerance = reg_opts.constraint_tolerance,
-            g_floor = reg_opts.g_floor,
-            chain_enabled = reg_opts.chain_enabled,
-            backend = reg_opts.backend,
-            warn_on_fallback = reg_opts.warn_on_fallback,
-            collision_bounce_radius = reg_opts.collision_bounce_radius,
-        )
-        sol_b = solve(prob_b, alg)
-
-        @test sol_a.retcode === sol_b.retcode
-        @test length(sol_a.t) == length(sol_b.t)
-        max_q = maximum(maximum(abs, sol_a.q[i] .- sol_b.q[i]) for i in eachindex(sol_a.q))
-        max_p = maximum(maximum(abs, sol_a.p[i] .- sol_b.p[i]) for i in eachindex(sol_a.p))
-        @test max_q == 0.0
-        @test max_p == 0.0
     end
 end

--- a/test/test_types.jl
+++ b/test/test_types.jl
@@ -95,10 +95,6 @@
         @test kappas(prob) == [1.0]  # unlike charges but Zöllner disabled → κ=1
         @test prob.zollner.enabled == false
         @test prob.zollner.a == 0.0
-        @test prob.regularization.enabled == false
-        @test prob.regularization.r_on === nothing
-        @test prob.regularization.r_off === nothing
-        @test prob.regularization.max_substeps == 512
 
         # Custom convergence_tolerance and maximum_iterations
         prob2 = HamiltonianProblem(
@@ -112,19 +108,9 @@
             dt = 0.01,
             convergence_tolerance = 1e-10,
             maximum_iterations = 50,
-            regularization = RegularizationOptions(
-                enabled = false,
-                r_on = 0.2,
-                r_off = 0.3,
-                max_substeps = 64,
-            ),
         )
         @test prob2.convergence_tolerance == 1e-10
         @test prob2.maximum_iterations == 50
-        @test prob2.regularization.enabled == false
-        @test prob2.regularization.r_on == 0.2
-        @test prob2.regularization.r_off == 0.3
-        @test prob2.regularization.max_substeps == 64
 
         # Validation errors
         @test_throws AssertionError HamiltonianProblem(

--- a/test/test_zollner.jl
+++ b/test/test_zollner.jl
@@ -165,9 +165,9 @@
             [1.0, 0.0, -1.0, 0.0], [0.0, 0.5, 0.0, -0.5];
             masses = [1.0, 1.0], charges = [1.0, -1.0], c = 10.0, dt = 0.005,
             zollner = ZollnerOptions(enabled = true, a = 0.01),
-            regularization = RegularizationOptions(enabled = true),
         )
-        sol = solve(prob, SymmetricProjectionIntegrator())
+        alg = RegularizedIntegrator(SymmetricProjectionIntegrator())
+        sol = solve(prob, alg)
         @test sol.retcode == :Success
         @test length(sol.t) > 1
     end
@@ -193,15 +193,15 @@
             sys, (0.0, 1.0), q0, p0;
             masses = [m1, m2], charges = [q1, q2], c = c, dt = 0.001,
             zollner = ZollnerOptions(enabled = true, a = a),
-            regularization = RegularizationOptions(
-                enabled = true,
-                backend = :adaptive_cartesian,
-                warn_on_fallback = false,
-                r_on = 0.15,
-                r_off = 0.25,
-            ),
         )
-        sol = solve(prob, SymmetricProjectionIntegrator())
+        alg = RegularizedIntegrator(
+            SymmetricProjectionIntegrator();
+            backend = :adaptive_cartesian,
+            warn_on_fallback = false,
+            r_on = 0.15,
+            r_off = 0.25,
+        )
+        sol = solve(prob, alg)
         @test sol.retcode == :Success
         # r0 < r_on so regularization fires on every step.
         @test sol.regularization.pair_steps > 0


### PR DESCRIPTION
## Summary

Phase 3d.2 of the architectural refactor. Regularization options now live exclusively on `RegularizedIntegrator`; `HamiltonianProblem` no longer carries a `regularization::RegularizationOptions` field.

- Wrapper owns the options; cache allocator reads them via `SymmetricProjectionBuffers(prob, alg.options)`
- `_step_core!` / `_allocate_cache` / `_resolve_callbacks` dispatch per-algorithm, with `RegularizedIntegrator` methods moved into `src/integrators/regularized.jl` (included after `solve.jl` so the wrapper type is in scope)
- `_step_unregularized!` and the regularized-substep loops now unwrap via `base_algorithm(integrator.alg)` before calling `_projected_cartesian_step!`, so wrapped and bare algorithms share the projection kernel
- `CollisionBounce` synthesis from `collision_bounce_radius` moves from the prob-level bridge to the wrapper
- Tests build `prob` and `alg` independently and pass both to `solve`; direct `RegularizationBuffers(...)` calls gain the required `RegularizationOptions()` final arg; the obsolete "equivalence with prob-level regularization" testset is deleted
- Regression fixtures replay bit-exactly (three at 0.0 drift, `threebody_mixed` at 8e-20 q / 6e-19 p, well under 1e-12 gate)

## Test plan

- [x] `julia --project=. -e 'using Pkg; Pkg.test()'` — 20417 pass, 0 fail
- [x] All four regression fixtures agree within 1e-12
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)