### PR TITLE
refactor: drop zollner field from HamiltonianProblem (Phase 3d.3)

### DIFF
--- a/ext/WeberElectrodynamicsMakieExt.jl
+++ b/ext/WeberElectrodynamicsMakieExt.jl
@@ -908,20 +908,7 @@ end
 
 function _make_extended_problem(prob::HamiltonianProblem)
     max_time = prob.tspan[1] + 1000 * prob.dt
-    return HamiltonianProblem(
-        prob.system,
-        (prob.tspan[1], max_time),
-        prob.q_initial,
-        prob.p_initial;
-        masses = masses(prob),
-        charges = charges(prob),
-        c = speed_of_light(prob),
-        dt = prob.dt,
-        convergence_tolerance = prob.convergence_tolerance,
-        maximum_iterations = prob.maximum_iterations,
-        regularization = regularization(prob),
-        zollner = zollner(prob),
-    )
+    return WeberElectrodynamics._with_tspan(prob, (prob.tspan[1], max_time))
 end
 
 # =============================================================================

--- a/src/WeberElectrodynamics.jl
+++ b/src/WeberElectrodynamics.jl
@@ -24,7 +24,7 @@ export RegularizationOptions
 export RegularizationDiagnostics
 export ZollnerOptions
 export SymmetricProjectionIntegrator
-export masses, charges, speed_of_light, kappas, params, zollner
+export masses, charges, speed_of_light, kappas, params
 
 # =============================================================================
 # Regularization Helpers
@@ -177,7 +177,8 @@ Visualise Zöllner potential contributions against standard Weber energies.
 
 Two-panel layout: total potential with per-pair breakdown and Zöllner extra terms
 (κ values shown); Zöllner gravitational residual ΣΔV_Z compared to total energy.
-Only meaningful when `prob.zollner.enabled == true`.
+Only meaningful when the problem was constructed with Zöllner enabled
+(non-trivial `kappas(prob)`).
 
 Requires `using Plots` to activate the Plots.jl extension.
 """

--- a/src/types.jl
+++ b/src/types.jl
@@ -449,7 +449,9 @@ and solver/regularization options into a single immutable structure.
 - `convergence_tolerance=1e-13`: Fixed-point convergence threshold for projection.
 - `maximum_iterations=100`: Maximum projection iterations per step.
 - `zollner=ZollnerOptions()`: Zöllner electrogravitational extension options.
-  See `ZollnerOptions` for all available fields.
+  See `ZollnerOptions` for all available fields. The options are used at
+  construction time to compute the per-pair `κ` values packed into `params`
+  and are **not** retained on the problem; inspect κ via `kappas(prob)`.
 
 Regularization options moved to [`RegularizedIntegrator`](@ref); pass them via
 `solve(prob, RegularizedIntegrator(SymmetricProjectionIntegrator(); ...))`.
@@ -463,7 +465,6 @@ Regularization options moved to [`RegularizedIntegrator`](@ref); pass them via
 - `dt::Float64`: Fixed step size.
 - `convergence_tolerance::Float64`: Projection convergence threshold.
 - `maximum_iterations::Int`: Maximum projection iterations per step.
-- `zollner::ZollnerOptions`: Zöllner extension configuration.
 """
 struct HamiltonianProblem
     system::HamiltonianSystem
@@ -474,7 +475,6 @@ struct HamiltonianProblem
     dt::Float64
     convergence_tolerance::Float64
     maximum_iterations::Int
-    zollner::ZollnerOptions
 
     function HamiltonianProblem(
         system::HamiltonianSystem,
@@ -518,7 +518,6 @@ struct HamiltonianProblem
             Float64(dt),
             Float64(convergence_tolerance),
             Int(maximum_iterations),
-            zollner,
         )
     end
 end
@@ -531,7 +530,6 @@ end
     speed_of_light(prob::HamiltonianProblem) -> Float64
     kappas(prob::HamiltonianProblem) -> AbstractVector{Float64}
     params(prob::HamiltonianProblem) -> Vector{Float64}
-    zollner(prob::HamiltonianProblem) -> ZollnerOptions
 
 Read-only accessors. `masses`, `charges`, and `kappas` return views into the
 backing `params` vector (layout `[m₁…mₙ, q₁…qₙ, c, κ…]`), so they are O(1)
@@ -545,7 +543,24 @@ charges(prob::HamiltonianProblem) =
 speed_of_light(prob::HamiltonianProblem) = prob.params[2*n_particles(prob)+1]
 kappas(prob::HamiltonianProblem) = @view prob.params[2*n_particles(prob)+2:end]
 params(prob::HamiltonianProblem) = prob.params
-zollner(prob::HamiltonianProblem) = prob.zollner
+
+# Internal: clone a problem with an overridden tspan while preserving the
+# compiled system, initial conditions, and packed params (including any
+# Zöllner-derived κ values). Used by the Makie streaming animation to extend
+# the integration horizon without needing to re-derive the construction inputs.
+function _with_tspan(prob::HamiltonianProblem, tspan::Tuple{Real,Real})
+    return HamiltonianProblem(
+        prob.system,
+        prob.tspan,
+        prob.q_initial,
+        prob.p_initial,
+        copy(prob.params),
+        prob.dt,
+        prob.convergence_tolerance,
+        prob.maximum_iterations,
+        (Float64(tspan[1]), Float64(tspan[2])),
+    )
+end
 
 """
     HamiltonianSolution

--- a/test/regression/capture.jl
+++ b/test/regression/capture.jl
@@ -138,7 +138,7 @@ function fixture_twobody_ellipse()
     )
     alg = SymmetricProjectionIntegrator()
     sol = solve(prob, alg)
-    return prob, alg, sol, "twobody_ellipse",
+    return prob, alg, sol, ZollnerOptions(), "twobody_ellipse",
         "2-body unregularized bound elliptic orbit (finite c, mild eccentricity)"
 end
 
@@ -159,7 +159,7 @@ function fixture_threebody_mixed()
     )
     alg = SymmetricProjectionIntegrator()
     sol = solve(prob, alg)
-    return prob, alg, sol, "threebody_mixed",
+    return prob, alg, sol, ZollnerOptions(), "threebody_mixed",
         "3-body unregularized mixed-charge system starting from rest"
 end
 
@@ -197,7 +197,7 @@ function fixture_close_approach_lifted()
         warn_on_fallback = false,
     )
     sol = solve(prob, alg)
-    return prob, alg, sol, "close_approach_lifted",
+    return prob, alg, sol, ZollnerOptions(), "close_approach_lifted",
         "2-body close approach with :lifted_pair Levi-Civita regularization"
 end
 
@@ -238,7 +238,7 @@ function fixture_zollner_offmatch()
         warn_on_fallback = false,
     )
     sol = solve(prob, alg)
-    return prob, alg, sol, "zollner_offmatch",
+    return prob, alg, sol, zol, "zollner_offmatch",
         "2-body Zöllner off-match (a≠0) with adaptive-Cartesian regularization"
 end
 
@@ -257,6 +257,7 @@ function save_fixture(
     prob::HamiltonianProblem,
     alg,
     sol::HamiltonianSolution,
+    zol::ZollnerOptions,
     name::String,
     desc::String,
 )
@@ -275,7 +276,7 @@ function save_fixture(
         "convergence_tolerance" => prob.convergence_tolerance,
         "maximum_iterations" => prob.maximum_iterations,
         "regularization" => reg_opts_to_dict(_alg_reg_opts(alg)),
-        "zollner" => zollner_opts_to_dict(prob.zollner),
+        "zollner" => zollner_opts_to_dict(zol),
     )
 
     fixture = Dict{String,Any}(
@@ -316,10 +317,10 @@ function main()
         name_guess = string(nameof(builder))
         print("Building $name_guess ... ")
         t0 = time()
-        prob, alg, sol, name, desc = builder()
+        prob, alg, sol, zol, name, desc = builder()
         elapsed = time() - t0
         println("solve=$(round(elapsed; digits=2))s")
-        save_fixture(prob, alg, sol, name, desc)
+        save_fixture(prob, alg, sol, zol, name, desc)
         if sol.retcode != :Success
             error("Fixture $name produced retcode=$(sol.retcode); aborting.")
         end

--- a/test/test_accessors.jl
+++ b/test/test_accessors.jl
@@ -45,16 +45,4 @@
         @test κ ≈ [1.1, 1.0, 1.1]
     end
 
-    @testset "zollner options accessor" begin
-        zopts = ZollnerOptions(enabled = true, a = 0.05)
-        prob = HamiltonianProblem(
-            sys, (0.0, 1.0), zeros(6), zeros(6);
-            masses = [1.0, 1.0, 1.0],
-            charges = [1.0, -1.0, 1.0],
-            c = 10.0,
-            dt = 0.01,
-            zollner = zopts,
-        )
-        @test zollner(prob) === zopts
-    end
 end

--- a/test/test_types.jl
+++ b/test/test_types.jl
@@ -93,8 +93,6 @@
         # params = [m1, m2, q1, q2, c, κ₁₂]; charges +1/-1 are unlike so κ=1 (Zöllner disabled)
         @test params(prob) == [1.0, 0.5, 1.0, -1.0, 4.0, 1.0]
         @test kappas(prob) == [1.0]  # unlike charges but Zöllner disabled → κ=1
-        @test prob.zollner.enabled == false
-        @test prob.zollner.a == 0.0
 
         # Custom convergence_tolerance and maximum_iterations
         prob2 = HamiltonianProblem(

--- a/test/test_zollner.jl
+++ b/test/test_zollner.jl
@@ -32,8 +32,6 @@
         )
         @test length(kappas(prob)) == 1
         @test kappas(prob)[1] ≈ 1.1  # 1 + a for unlike charges
-        @test prob.zollner.enabled == true
-        @test prob.zollner.a == 0.1
     end
 
     @testset "Kappa computation — like charges" begin


### PR DESCRIPTION
## Summary
- Drops the `zollner::ZollnerOptions` field and `zollner(prob)` accessor from `HamiltonianProblem` — options are used once at construction to compute κ values packed into `params`, then discarded. Inspect κ via `kappas(prob)`.
- Adds an internal `_with_tspan(prob, tspan)` clone helper used by the Makie streaming animation, replacing a stale kwarg-rebuild that referenced the (already-removed) `regularization(prob)` / `zollner(prob)` accessors.
- Threads `ZollnerOptions` through the regression capture script as an explicit builder return value.
- Public surface retains the `zollner=ZollnerOptions()` kwarg and the `ZollnerOptions` struct — only the field/accessor are gone.

This completes Phase 3d of the refactor plan: `HamiltonianProblem` now holds only system-agnostic state (`system, tspan, q0, p0, params, dt, tol, maxiter`).

## Test plan
- [x] Full test suite green (20412 tests)
- [x] Regression fixtures bit-exact: 3 at 0.0 drift, `threebody_mixed` at 8e-20 q / 6e-19 p — well under the 1e-12 gate
- [x] `capture.jl` regenerates fixtures cleanly
- [x] Makie extension compiles under `using GLMakie`

🤖 Generated with [Claude Code](https://claude.com/claude-code)