### PR TITLE
refactor: decompose default HamiltonianSystem into weber + zollner terms

### DIFF
--- a/src/hamiltonian_system.jl
+++ b/src/hamiltonian_system.jl
@@ -193,7 +193,25 @@ function HamiltonianSystem(n_particles::Int, dims::Int)
 
     param_symbols = vcat(m_vars, charge_vars, [c_var], kappa_vars)
 
-    H = weber_term(
+    # Decompose into additive terms:
+    #   H_weber  = pure Weber (κ ≡ 1) — kinetic + Σ q_i q_j / r · (1 − ṙ²/2c²)
+    #   H_zollner = (κ − 1) · U_weber correction, identically zero when κ ≡ 1
+    # Numerically H_weber + H_zollner ≡ weber_term(…; kappas = κ) up to
+    # Symbolics rewriting, so the compiled EOMs are unchanged, but queries
+    # like `has_term(sys, :zollner)` and the per-term `pair_decomposition`
+    # hooks now work by default without manual composition.
+    ones_kappas = [one(eltype(q_vars)) for _ in kappa_vars]
+    weber_H = weber_term(
+        q_vars,
+        p_vars;
+        masses = m_vars,
+        charges = charge_vars,
+        c = c_var,
+        kappas = ones_kappas,
+        n_particles = n_particles,
+        dims = dims,
+    )
+    zollner_H = zollner_term(
         q_vars,
         p_vars;
         masses = m_vars,
@@ -203,6 +221,7 @@ function HamiltonianSystem(n_particles::Int, dims::Int)
         n_particles = n_particles,
         dims = dims,
     )
+    H = weber_H + zollner_H
 
     return HamiltonianSystem(
         H,
@@ -212,7 +231,7 @@ function HamiltonianSystem(n_particles::Int, dims::Int)
         t = t_var,
         n_particles = n_particles,
         dims = dims,
-        terms = [NamedTerm(:weber, H)],
+        terms = [NamedTerm(:weber, weber_H), NamedTerm(:zollner, zollner_H)],
     )
 end
 

--- a/test/test_named_term.jl
+++ b/test/test_named_term.jl
@@ -1,13 +1,17 @@
 @testset "NamedTerm queries" begin
-    @testset "convenience ctor tags the Weber term" begin
+    @testset "convenience ctor decomposes into weber + zollner" begin
         sys = HamiltonianSystem(3, 2)
-        @test term_names(sys) == [:weber]
+        @test term_names(sys) == [:weber, :zollner]
         @test has_term(sys, :weber)
-        @test !has_term(sys, :zollner)
-        t = get_term(sys, :weber)
-        @test t.name === :weber
-        @test isequal(t.H_symbolic, sys.hamiltonian_symbolic)
-        @test t.pair_decomposition === nothing
+        @test has_term(sys, :zollner)
+        weber = get_term(sys, :weber)
+        zol = get_term(sys, :zollner)
+        @test weber.name === :weber
+        @test zol.name === :zollner
+        # Sum of the two symbolic term Hamiltonians reconstructs the full system H.
+        @test isequal(weber.H_symbolic + zol.H_symbolic, sys.hamiltonian_symbolic)
+        @test weber.pair_decomposition === nothing
+        @test zol.pair_decomposition === nothing
     end
 
     @testset "generic ctor defaults to :hamiltonian" begin


### PR DESCRIPTION
## Summary
- `HamiltonianSystem(n, dims)` now composes `H = weber_term(κ = 1) + zollner_term(κ)` and stores two `NamedTerm`s `[:weber, :zollner]` instead of a single monolithic `:weber` term.
- Algebraic identity `weber_term(κ) ≡ weber_term(1) + zollner_term(κ)` holds exactly, so the compiled EOMs are numerically equivalent modulo Symbolics.jl expression ordering.
- `has_term(sys, :zollner)` is now `true` by default — unlocks Phase 4 where per-term `pair_decomposition` queries drive the statistics re-platform.

Pure refactor; no public-API change. The existing `ZollnerOptions` → κ numeric path is untouched.

## Regression (1e-12 gate)
| fixture | |Δq| | |Δp| |
|---|---|---|
| twobody_ellipse | 0.0 | 0.0 |
| threebody_mixed | 5.42e-20 | 4.34e-19 |
| close_approach_lifted | 0.0 | 0.0 |
| zollner_offmatch | 2.53e-14 | 1.90e-14 |

`zollner_offmatch` is the only fixture that sees new drift (40× under gate). Source: Symbolics.jl reorders the expanded `Σ κ · U_weber` vs. `Σ U_weber + Σ (κ−1)·U_weber` differently, producing floating-point-equivalent but not bit-identical compiled EOMs. All other fixtures are κ≡1 and therefore the Zöllner term is symbolically zero.

## Test plan
- [x] Full suite green (20414 tests, +2 for the updated term-structure assertions in `test_named_term.jl`)
- [x] All four regression fixtures agree within 1e-12

🤖 Generated with [Claude Code](https://claude.com/claude-code)