### PR TITLE
refactor: attach pair_decomposition closures to :weber and :zollner terms

### DIFF
--- a/src/hamiltonian/builders/weber.jl
+++ b/src/hamiltonian/builders/weber.jl
@@ -23,55 +23,6 @@ directly lets a user compose a custom Hamiltonian, e.g.
   ordered by `i<j` and indexed via `_pair_index`).
 - `n_particles::Int`, `dims::Int`: Problem shape.
 """
-# Concrete per-pair numeric decomposition of the Weber pair potential, matching
-# the symbolic `weber_term` body. The closure is attached to the `:weber`
-# NamedTerm by `HamiltonianSystem(n, dims)` and queried by statistics.
-#
-# Returns a NamedTuple `(coulomb, velocity, rdot, r)` where
-#   coulomb  = κ·q_i·q_j / r                                    (Coulomb part)
-#   velocity = −coulomb · ṙ² / (2c²)                            (Weber velocity part)
-#   rdot     = ṙ = (q_i − q_j)·(v_i − v_j) / r                  (radial velocity)
-#   r        = |q_i − q_j|                                      (pair distance)
-# `coulomb + velocity` is the full Weber-pair contribution to H (κ-scaled).
-function _weber_pair_decomposition(
-    i::Int,
-    j::Int,
-    q::AbstractVector{Float64},
-    p::AbstractVector{Float64},
-    params::AbstractVector{Float64},
-    n_particles::Int,
-    dims::Int,
-)
-    @inbounds mi = params[i]
-    @inbounds mj = params[j]
-    @inbounds qi = params[n_particles+i]
-    @inbounds qj = params[n_particles+j]
-    @inbounds c = params[2*n_particles+1]
-    @inbounds κ = params[2*n_particles+1+_pair_index(i, j, n_particles)]
-
-    qi_start = (i - 1) * dims + 1
-    qj_start = (j - 1) * dims + 1
-
-    r_squared = 0.0
-    @inbounds for d = 0:(dims-1)
-        dq = q[qi_start+d] - q[qj_start+d]
-        r_squared += dq * dq
-    end
-    r = sqrt(r_squared)
-
-    r_dot_v = 0.0
-    @inbounds for d = 0:(dims-1)
-        dq = q[qi_start+d] - q[qj_start+d]
-        dv = p[qi_start+d] / mi - p[qj_start+d] / mj
-        r_dot_v += dq * dv
-    end
-    rdot = r_dot_v / r
-
-    coulomb = κ * qi * qj / r
-    velocity = -coulomb * rdot^2 / (2 * c^2)
-    return (coulomb = coulomb, velocity = velocity, rdot = rdot, r = r)
-end
-
 function weber_term(
     q_vars::AbstractVector,
     p_vars::AbstractVector;
@@ -124,4 +75,53 @@ function weber_term(
     end
 
     return H
+end
+
+# Concrete per-pair numeric decomposition of the Weber pair potential, matching
+# the symbolic `weber_term` body. The closure is attached to the `:weber`
+# NamedTerm by `HamiltonianSystem(n, dims)` and queried by statistics.
+#
+# Returns a NamedTuple `(coulomb, velocity, rdot, r)` where
+#   coulomb  = κ·q_i·q_j / r                                    (Coulomb part)
+#   velocity = −coulomb · ṙ² / (2c²)                            (Weber velocity part)
+#   rdot     = ṙ = (q_i − q_j)·(v_i − v_j) / r                  (radial velocity)
+#   r        = |q_i − q_j|                                      (pair distance)
+# `coulomb + velocity` is the full Weber-pair contribution to H (κ-scaled).
+function _weber_pair_decomposition(
+    i::Int,
+    j::Int,
+    q::AbstractVector{Float64},
+    p::AbstractVector{Float64},
+    params::AbstractVector{Float64},
+    n_particles::Int,
+    dims::Int,
+)
+    @inbounds mi = params[i]
+    @inbounds mj = params[j]
+    @inbounds qi = params[n_particles+i]
+    @inbounds qj = params[n_particles+j]
+    @inbounds c = params[2*n_particles+1]
+    @inbounds κ = params[2*n_particles+1+_pair_index(i, j, n_particles)]
+
+    qi_start = (i - 1) * dims + 1
+    qj_start = (j - 1) * dims + 1
+
+    r_squared = 0.0
+    @inbounds for d = 0:(dims-1)
+        dq = q[qi_start+d] - q[qj_start+d]
+        r_squared += dq * dq
+    end
+    r = sqrt(r_squared)
+
+    r_dot_v = 0.0
+    @inbounds for d = 0:(dims-1)
+        dq = q[qi_start+d] - q[qj_start+d]
+        dv = p[qi_start+d] / mi - p[qj_start+d] / mj
+        r_dot_v += dq * dv
+    end
+    rdot = r_dot_v / r
+
+    coulomb = κ * qi * qj / r
+    velocity = -coulomb * rdot^2 / (2 * c^2)
+    return (coulomb = coulomb, velocity = velocity, rdot = rdot, r = r)
 end

--- a/src/hamiltonian/builders/weber.jl
+++ b/src/hamiltonian/builders/weber.jl
@@ -23,6 +23,55 @@ directly lets a user compose a custom Hamiltonian, e.g.
   ordered by `i<j` and indexed via `_pair_index`).
 - `n_particles::Int`, `dims::Int`: Problem shape.
 """
+# Concrete per-pair numeric decomposition of the Weber pair potential, matching
+# the symbolic `weber_term` body. The closure is attached to the `:weber`
+# NamedTerm by `HamiltonianSystem(n, dims)` and queried by statistics.
+#
+# Returns a NamedTuple `(coulomb, velocity, rdot, r)` where
+#   coulomb  = κ·q_i·q_j / r                                    (Coulomb part)
+#   velocity = −coulomb · ṙ² / (2c²)                            (Weber velocity part)
+#   rdot     = ṙ = (q_i − q_j)·(v_i − v_j) / r                  (radial velocity)
+#   r        = |q_i − q_j|                                      (pair distance)
+# `coulomb + velocity` is the full Weber-pair contribution to H (κ-scaled).
+function _weber_pair_decomposition(
+    i::Int,
+    j::Int,
+    q::AbstractVector{Float64},
+    p::AbstractVector{Float64},
+    params::AbstractVector{Float64},
+    n_particles::Int,
+    dims::Int,
+)
+    @inbounds mi = params[i]
+    @inbounds mj = params[j]
+    @inbounds qi = params[n_particles+i]
+    @inbounds qj = params[n_particles+j]
+    @inbounds c = params[2*n_particles+1]
+    @inbounds κ = params[2*n_particles+1+_pair_index(i, j, n_particles)]
+
+    qi_start = (i - 1) * dims + 1
+    qj_start = (j - 1) * dims + 1
+
+    r_squared = 0.0
+    @inbounds for d = 0:(dims-1)
+        dq = q[qi_start+d] - q[qj_start+d]
+        r_squared += dq * dq
+    end
+    r = sqrt(r_squared)
+
+    r_dot_v = 0.0
+    @inbounds for d = 0:(dims-1)
+        dq = q[qi_start+d] - q[qj_start+d]
+        dv = p[qi_start+d] / mi - p[qj_start+d] / mj
+        r_dot_v += dq * dv
+    end
+    rdot = r_dot_v / r
+
+    coulomb = κ * qi * qj / r
+    velocity = -coulomb * rdot^2 / (2 * c^2)
+    return (coulomb = coulomb, velocity = velocity, rdot = rdot, r = r)
+end
+
 function weber_term(
     q_vars::AbstractVector,
     p_vars::AbstractVector;

--- a/src/hamiltonian/builders/zollner.jl
+++ b/src/hamiltonian/builders/zollner.jl
@@ -32,6 +32,51 @@ see `_compute_zollner_kappas`.
   `_pair_index`).
 - `n_particles::Int`, `dims::Int`: Problem shape.
 """
+# Concrete per-pair numeric decomposition of the Zöllner correction, attached
+# to the `:zollner` NamedTerm by `HamiltonianSystem(n, dims)`.
+#
+# Returns a NamedTuple `(zollner_extra, r, rdot)` where
+#   zollner_extra = (κ − 1)·q_i·q_j/r · (1 − ṙ²/(2c²))
+# This is the residual of the Zöllner-modified pair potential relative to
+# pure Weber (κ ≡ 1).
+function _zollner_pair_decomposition(
+    i::Int,
+    j::Int,
+    q::AbstractVector{Float64},
+    p::AbstractVector{Float64},
+    params::AbstractVector{Float64},
+    n_particles::Int,
+    dims::Int,
+)
+    @inbounds mi = params[i]
+    @inbounds mj = params[j]
+    @inbounds qi = params[n_particles+i]
+    @inbounds qj = params[n_particles+j]
+    @inbounds c = params[2*n_particles+1]
+    @inbounds κ = params[2*n_particles+1+_pair_index(i, j, n_particles)]
+
+    qi_start = (i - 1) * dims + 1
+    qj_start = (j - 1) * dims + 1
+
+    r_squared = 0.0
+    @inbounds for d = 0:(dims-1)
+        dq = q[qi_start+d] - q[qj_start+d]
+        r_squared += dq * dq
+    end
+    r = sqrt(r_squared)
+
+    r_dot_v = 0.0
+    @inbounds for d = 0:(dims-1)
+        dq = q[qi_start+d] - q[qj_start+d]
+        dv = p[qi_start+d] / mi - p[qj_start+d] / mj
+        r_dot_v += dq * dv
+    end
+    rdot = r_dot_v / r
+
+    zollner_extra = (κ - 1.0) * qi * qj / r * (1.0 - rdot^2 / (2 * c^2))
+    return (zollner_extra = zollner_extra, r = r, rdot = rdot)
+end
+
 function zollner_term(
     q_vars::AbstractVector,
     p_vars::AbstractVector;

--- a/src/hamiltonian/builders/zollner.jl
+++ b/src/hamiltonian/builders/zollner.jl
@@ -32,51 +32,6 @@ see `_compute_zollner_kappas`.
   `_pair_index`).
 - `n_particles::Int`, `dims::Int`: Problem shape.
 """
-# Concrete per-pair numeric decomposition of the Zöllner correction, attached
-# to the `:zollner` NamedTerm by `HamiltonianSystem(n, dims)`.
-#
-# Returns a NamedTuple `(zollner_extra, r, rdot)` where
-#   zollner_extra = (κ − 1)·q_i·q_j/r · (1 − ṙ²/(2c²))
-# This is the residual of the Zöllner-modified pair potential relative to
-# pure Weber (κ ≡ 1).
-function _zollner_pair_decomposition(
-    i::Int,
-    j::Int,
-    q::AbstractVector{Float64},
-    p::AbstractVector{Float64},
-    params::AbstractVector{Float64},
-    n_particles::Int,
-    dims::Int,
-)
-    @inbounds mi = params[i]
-    @inbounds mj = params[j]
-    @inbounds qi = params[n_particles+i]
-    @inbounds qj = params[n_particles+j]
-    @inbounds c = params[2*n_particles+1]
-    @inbounds κ = params[2*n_particles+1+_pair_index(i, j, n_particles)]
-
-    qi_start = (i - 1) * dims + 1
-    qj_start = (j - 1) * dims + 1
-
-    r_squared = 0.0
-    @inbounds for d = 0:(dims-1)
-        dq = q[qi_start+d] - q[qj_start+d]
-        r_squared += dq * dq
-    end
-    r = sqrt(r_squared)
-
-    r_dot_v = 0.0
-    @inbounds for d = 0:(dims-1)
-        dq = q[qi_start+d] - q[qj_start+d]
-        dv = p[qi_start+d] / mi - p[qj_start+d] / mj
-        r_dot_v += dq * dv
-    end
-    rdot = r_dot_v / r
-
-    zollner_extra = (κ - 1.0) * qi * qj / r * (1.0 - rdot^2 / (2 * c^2))
-    return (zollner_extra = zollner_extra, r = r, rdot = rdot)
-end
-
 function zollner_term(
     q_vars::AbstractVector,
     p_vars::AbstractVector;
@@ -121,4 +76,49 @@ function zollner_term(
     end
 
     return H
+end
+
+# Concrete per-pair numeric decomposition of the Zöllner correction, attached
+# to the `:zollner` NamedTerm by `HamiltonianSystem(n, dims)`.
+#
+# Returns a NamedTuple `(zollner_extra, r, rdot)` where
+#   zollner_extra = (κ − 1)·q_i·q_j/r · (1 − ṙ²/(2c²))
+# This is the residual of the Zöllner-modified pair potential relative to
+# pure Weber (κ ≡ 1).
+function _zollner_pair_decomposition(
+    i::Int,
+    j::Int,
+    q::AbstractVector{Float64},
+    p::AbstractVector{Float64},
+    params::AbstractVector{Float64},
+    n_particles::Int,
+    dims::Int,
+)
+    @inbounds mi = params[i]
+    @inbounds mj = params[j]
+    @inbounds qi = params[n_particles+i]
+    @inbounds qj = params[n_particles+j]
+    @inbounds c = params[2*n_particles+1]
+    @inbounds κ = params[2*n_particles+1+_pair_index(i, j, n_particles)]
+
+    qi_start = (i - 1) * dims + 1
+    qj_start = (j - 1) * dims + 1
+
+    r_squared = 0.0
+    @inbounds for d = 0:(dims-1)
+        dq = q[qi_start+d] - q[qj_start+d]
+        r_squared += dq * dq
+    end
+    r = sqrt(r_squared)
+
+    r_dot_v = 0.0
+    @inbounds for d = 0:(dims-1)
+        dq = q[qi_start+d] - q[qj_start+d]
+        dv = p[qi_start+d] / mi - p[qj_start+d] / mj
+        r_dot_v += dq * dv
+    end
+    rdot = r_dot_v / r
+
+    zollner_extra = (κ - 1.0) * qi * qj / r * (1.0 - rdot^2 / (2 * c^2))
+    return (zollner_extra = zollner_extra, r = r, rdot = rdot)
 end

--- a/src/hamiltonian_system.jl
+++ b/src/hamiltonian_system.jl
@@ -223,6 +223,13 @@ function HamiltonianSystem(n_particles::Int, dims::Int)
     )
     H = weber_H + zollner_H
 
+    weber_decomp =
+        (i, j, q, p, params) ->
+            _weber_pair_decomposition(i, j, q, p, params, n_particles, dims)
+    zollner_decomp =
+        (i, j, q, p, params) ->
+            _zollner_pair_decomposition(i, j, q, p, params, n_particles, dims)
+
     return HamiltonianSystem(
         H,
         q_vars,
@@ -231,7 +238,10 @@ function HamiltonianSystem(n_particles::Int, dims::Int)
         t = t_var,
         n_particles = n_particles,
         dims = dims,
-        terms = [NamedTerm(:weber, weber_H), NamedTerm(:zollner, zollner_H)],
+        terms = [
+            NamedTerm(:weber, weber_H; pair_decomposition = weber_decomp),
+            NamedTerm(:zollner, zollner_H; pair_decomposition = zollner_decomp),
+        ],
     )
 end
 

--- a/test/test_named_term.jl
+++ b/test/test_named_term.jl
@@ -10,8 +10,76 @@
         @test zol.name === :zollner
         # Sum of the two symbolic term Hamiltonians reconstructs the full system H.
         @test isequal(weber.H_symbolic + zol.H_symbolic, sys.hamiltonian_symbolic)
-        @test weber.pair_decomposition === nothing
-        @test zol.pair_decomposition === nothing
+        @test weber.pair_decomposition !== nothing
+        @test zol.pair_decomposition !== nothing
+    end
+
+    @testset "pair_decomposition closures match compute_pair_weber_components" begin
+        sys = HamiltonianSystem(2, 2)
+        weber = get_term(sys, :weber)
+        zol = get_term(sys, :zollner)
+
+        q = [1.0, 0.2, -0.5, 0.3]
+        p = [0.1, 0.2, -0.15, -0.1]
+        # params = [m1, m2, q1, q2, c, κ12]
+        params = [1.0, 2.0, 1.0, -1.0, 5.0, 1.3]
+
+        masses = params[1:2]
+        charges = params[3:4]
+        c_val = params[5]
+        κ = params[6]
+
+        coulomb, velocity, rdot, zollner_extra =
+            WeberElectrodynamics.compute_pair_weber_components(
+                q, p, 1, 2, masses, charges, c_val, 2, κ,
+            )
+
+        wr = weber.pair_decomposition(1, 2, q, p, params)
+        zr = zol.pair_decomposition(1, 2, q, p, params)
+
+        @test wr.coulomb ≈ coulomb
+        @test wr.velocity ≈ velocity
+        @test wr.rdot ≈ rdot
+        @test wr.r ≈ sqrt((q[1] - q[3])^2 + (q[2] - q[4])^2)
+
+        @test zr.zollner_extra ≈ zollner_extra
+        @test zr.r ≈ wr.r
+        @test zr.rdot ≈ rdot
+
+        # κ = 1 → Zöllner contribution vanishes identically.
+        params_k1 = [1.0, 2.0, 1.0, -1.0, 5.0, 1.0]
+        zr1 = zol.pair_decomposition(1, 2, q, p, params_k1)
+        @test zr1.zollner_extra == 0.0
+    end
+
+    @testset "pair_decomposition closures in 3D" begin
+        sys = HamiltonianSystem(3, 3)
+        weber = get_term(sys, :weber)
+        zol = get_term(sys, :zollner)
+
+        q = [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.5, 0.2]
+        p = [0.1, 0.0, 0.0, -0.1, 0.05, 0.0, 0.0, -0.05, 0.02]
+        # params = [m1, m2, m3, q1, q2, q3, c, κ12, κ13, κ23]
+        params = [1.0, 1.0, 1.0, 1.0, -1.0, 1.0, 8.0, 1.1, 1.0, 1.2]
+
+        masses = params[1:3]
+        charges = params[4:6]
+        c_val = params[7]
+
+        for (i, j, κ) in ((1, 2, params[8]), (1, 3, params[9]), (2, 3, params[10]))
+            coulomb, velocity, rdot, zollner_extra =
+                WeberElectrodynamics.compute_pair_weber_components(
+                    q, p, i, j, masses, charges, c_val, 3, κ,
+                )
+
+            wr = weber.pair_decomposition(i, j, q, p, params)
+            zr = zol.pair_decomposition(i, j, q, p, params)
+
+            @test wr.coulomb ≈ coulomb
+            @test wr.velocity ≈ velocity
+            @test wr.rdot ≈ rdot
+            @test zr.zollner_extra ≈ zollner_extra
+        end
     end
 
     @testset "generic ctor defaults to :hamiltonian" begin


### PR DESCRIPTION
## Summary
- Add `_weber_pair_decomposition` and `_zollner_pair_decomposition` helpers in the respective builder files, mirroring the per-pair numeric body of the symbolic term builders.
- Wrap each helper as a closure (capturing `n_particles`, `dims`) and attach via `NamedTerm(...; pair_decomposition = ...)` in the default `HamiltonianSystem(n, dims)` constructor.
- Tests validate closure output against the hardcoded `compute_pair_weber_components` in 2D and 3D, both `κ = 1` and `κ ≠ 1`.

This is Step 4a of the Phase 4 statistics re-platform. Statistics callers (`compute_pair_weber_components` in `src/statistics/energy.jl`) will migrate to query the term-owned decomposition in a follow-up (Step 4b); this PR leaves existing callers untouched.

## Test plan
- [x] All 20434 tests pass.
- [x] Four regression fixtures agree to 1e-12 (unchanged).
- [x] New closure tests cover 2D and 3D, both the `κ = 1` degenerate and `κ ≠ 1` generic cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)