### PR TITLE
refactor: delegate pair energy decomposition to term closures

### DIFF
--- a/src/statistics/energy.jl
+++ b/src/statistics/energy.jl
@@ -252,8 +252,6 @@ function compute_energy_timeseries(solution::HamiltonianSolution; stride::Int = 
     n = n_particles(prob)
     d = dims(prob)
     ms = masses(prob)
-    qs = charges(prob)
-    c_val = speed_of_light(prob)
     params_vec = params(prob)
     κs = kappas(prob)
     hamiltonian_compiled = system.hamiltonian_compiled
@@ -290,6 +288,9 @@ function compute_energy_timeseries(solution::HamiltonianSolution; stride::Int = 
 
     total_zollner_residual = zeros(Float64, n_points)
 
+    weber_decomp = get_term(system, :weber).pair_decomposition
+    zollner_decomp = get_term(system, :zollner).pair_decomposition
+
     # Main computation loop
     @inbounds for (pt_idx, sol_idx) in enumerate(indices)
         q = solution.q[sol_idx]
@@ -305,9 +306,12 @@ function compute_energy_timeseries(solution::HamiltonianSolution; stride::Int = 
         zollner_sum = 0.0
         for i = 1:n
             for j = (i+1):n
-                kappa_ij = κs[_pair_index(i, j, n)]
-                coulomb, velocity, rdot, zollner_extra =
-                    compute_pair_weber_components(q, p, i, j, ms, qs, c_val, d, kappa_ij)
+                wc = weber_decomp(i, j, q, p, params_vec)
+                zc = zollner_decomp(i, j, q, p, params_vec)
+                coulomb = wc.coulomb
+                velocity = wc.velocity
+                rdot = wc.rdot
+                zollner_extra = zc.zollner_extra
                 pair_data = pair_energies[(i, j)]
                 pair_data.coulomb_term[pt_idx] = coulomb
                 pair_data.velocity_term[pt_idx] = velocity


### PR DESCRIPTION
## Summary
- `compute_energy_timeseries` now fetches the `:weber` and `:zollner` `NamedTerm.pair_decomposition` closures (attached in #56) and queries them per pair instead of calling the hardcoded `compute_pair_weber_components` helper.
- Returned quantities are identical (the closure bodies replicate the same math), so this is a pure delegation change — all four regression fixtures unchanged.
- `compute_pair_weber_components` remains as a standalone numerical helper exported for `test/test_statistics.jl` direct-call coverage; the main statistics pipeline no longer depends on it.

This is Step 4b of the Phase 4 statistics re-platform. Phase 4 still owes: (a) migrating `compute_pair_force_timeseries` and momentum/trajectory helpers to accessor-based access, and (b) the Plots/Makie extension accessor sweep.

Design note: the term closures intentionally do **not** compose additively (they report a κ-weighted "combined view" of each pair, not the κ=1 slice owned by `:weber`). This matches the pre-existing `compute_pair_weber_components` semantics, so this PR is a drop-in delegation. See [memory note](../memory/project_pair_decomposition_composition.md) for the deferred Option (b) if we ever need a truly additive composition.

## Test plan
- [x] All 20434 tests pass (`Pkg.test()`).
- [x] Four regression fixtures agree to 1e-12 (unchanged — bit-exact).
- [x] `compute_energy_timeseries` still exercised via existing tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)