### PR TITLE
refactor: migrate Plots ext plot_weber_vs_zollner to accessors

### DIFF
--- a/ext/WeberElectrodynamicsPlotsExt.jl
+++ b/ext/WeberElectrodynamicsPlotsExt.jl
@@ -959,15 +959,15 @@ function WeberElectrodynamics.plot_weber_vs_zollner(
     sol2::HamiltonianSolution;
     labels::Vector{String} = ["Weber", "Zöllner"],
 )::Plots.Plot
-    n1 = sol1.prob.system.n_particles
-    n2 = sol2.prob.system.n_particles
-    dims = sol1.prob.system.dims
+    n1 = n_particles(sol1.prob)
+    n2 = n_particles(sol2.prob)
+    d = dims(sol1.prob)
     @assert n1 == n2 "Both solutions must have the same number of particles"
-    @assert dims == sol2.prob.system.dims "Both solutions must have the same dimensions"
-    @assert dims in (2, 3) "Trajectory comparison only supported for 2D and 3D"
+    @assert d == dims(sol2.prob) "Both solutions must have the same dimensions"
+    @assert d in (2, 3) "Trajectory comparison only supported for 2D and 3D"
 
-    traj1 = compute_trajectory_data(sol1, n1, dims)
-    traj2 = compute_trajectory_data(sol2, n2, dims)
+    traj1 = compute_trajectory_data(sol1, n1, d)
+    traj2 = compute_trajectory_data(sol2, n2, d)
 
     colors = [:steelblue, :firebrick, :forestgreen, :darkorchid, :darkorange]
 
@@ -981,7 +981,7 @@ function WeberElectrodynamics.plot_weber_vs_zollner(
         size = _square_size(),
     )
 
-    if dims == 2
+    if d == 2
         for particle = 1:n1
             c = colors[mod1(particle, length(colors))]
             plot!(


### PR DESCRIPTION
## Summary
- `plot_weber_vs_zollner` now reads `n_particles(prob)` / `dims(prob)` via accessors instead of `sol.prob.system.*` field access
- Local `dims` renamed to `d` to avoid shadowing the module-level accessor function
- Only the one remaining site in the Plots extension that reached into `sol.prob.system` directly (grep-verified)

## Scope
Narrowest next step in Phase 4 after momentum.jl. Makie extension (~18 identical hits) will follow as its own PR; forces.jl already accepts geometry/physics as positional args and uses `kappas(prob)` internally, so it has no field access to migrate.

## Test plan
- [x] Full test suite: 20434 / 20434 pass
- [x] Regression fixtures: all four agree within 1e-12
- [x] Smoke test: `plot_weber_vs_zollner(sol, sol)` returns a valid `Plots.Plot`

🤖 Generated with [Claude Code](https://claude.com/claude-code)