### PR TITLE
docs: update trajectories.jl docstring to use dims(prob) accessor

### DIFF
--- a/src/statistics/trajectories.jl
+++ b/src/statistics/trajectories.jl
@@ -29,7 +29,7 @@ Extract per-particle position trajectories from a `HamiltonianSolution`.
 # Arguments
 - `sol::HamiltonianSolution`: Completed simulation result.
 - `n_particles::Int`: Number of particles encoded in `sol`.
-- `dims::Int`: Spatial dimension (must match `sol.prob.system.dims`).
+- `dims::Int`: Spatial dimension (must match `dims(sol.prob)`).
 
 # Keywords
 - `stride=1`: Downsample factor; every `stride`-th timestep is included.


### PR DESCRIPTION
## Summary
Last stale `sol.prob.system.dims` reference in the statistics layer. Updates the docstring to use the public `dims(sol.prob)` accessor for consistency with Phase 4.

## Scope
Pure doc polish — one line, no runtime impact.

## Test plan
- No code change; existing tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)