### PR TITLE
docs: rewire regularization opt-in to RegularizedIntegrator wrapper

### DIFF
--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -75,7 +75,8 @@ Neither backend regularizes Weber's velocity-dependent force — only the Coulom
 
 ### Collision bounce
 
-- Enabled via `RegularizationOptions(collision_bounce_radius = <r>)` passed to `HamiltonianProblem` (default 0.0 = off)
+- Implemented as the `CollisionBounce(radius)` callback; pass it to `solve` (or `init`) via the `callbacks` kwarg
+- `RegularizedIntegrator` also accepts a `collision_bounce_radius` kwarg and synthesises a matching callback automatically when no `CollisionBounce` is supplied
 - Only valid for ℓ=0 (head-on) collisions
 - Works best with the **unregularized** integrator (symplectic error stays bounded)
 
@@ -83,7 +84,7 @@ Neither backend regularizes Weber's velocity-dependent force — only the Coulom
 
 - `ZollnerOptions(enabled, a)` — mismatch parameter `a`
 - κ_ij = 1+a for unlike-sign charge pairs, 1.0 for like-sign
-- Stored in `HamiltonianProblem.kappas` and appended to the params vector automatically
+- Computed at `HamiltonianProblem` construction and packed into `params`; read via the `kappas(prob)` accessor
 
 ### Makie animation extension
 
@@ -93,7 +94,10 @@ Neither backend regularizes Weber's velocity-dependent force — only the Coulom
 
 ### Immutable options pattern
 
-`RegularizationOptions`, `ZollnerOptions` are immutable structs created once per problem. Pass configuration through `HamiltonianProblem` keyword arguments rather than mutating options.
+`RegularizationOptions` and `ZollnerOptions` are immutable structs — create them once, never mutate. They sit at different layers:
+
+- `ZollnerOptions` is problem-level: pass it via the `zollner = …` kwarg of `HamiltonianProblem`. It is used at construction to compute per-pair κ values and is not retained on the problem.
+- `RegularizationOptions` is algorithm-level: it lives inside `RegularizedIntegrator`. Use the `RegularizedIntegrator(base_alg; kwargs...)` constructor (its kwargs mirror `RegularizationOptions`) rather than building the options struct by hand.
 
 ---
 

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -170,8 +170,8 @@ The integrator above runs the core unregularized symplectic method. Two optional
 extensions can be enabled explicitly:
 
 - **[Regularization](regularization.md)** — Levi-Civita / KS handling for
-  close encounters. Pass `regularization = RegularizationOptions(enabled = true)`
-  to `HamiltonianProblem`.
+  close encounters. Wrap the base algorithm:
+  `solve(prob, RegularizedIntegrator(SymmetricProjectionIntegrator()))`.
 - **[Zöllner Extension](zollner.md)** — research feature implementing Zöllner's
   electrogravitational mismatch hypothesis. Pass
   `zollner = ZollnerOptions(enabled = true, a = <value>)` to `HamiltonianProblem`.

--- a/docs/src/regularization.md
+++ b/docs/src/regularization.md
@@ -1,8 +1,8 @@
 # Regularization
 
 Regularization is an **optional, advanced** feature. The core integrator runs
-unregularized by default; pass `regularization = RegularizationOptions(enabled = true)`
-to opt in.
+unregularized by default; opt in by wrapping the base algorithm in a
+[`RegularizedIntegrator`](@ref) and passing it to `solve`.
 
 ## When to use it
 
@@ -27,9 +27,15 @@ prob = HamiltonianProblem(
     charges = [1.0, -1.0],
     c       = 10.0,
     dt      = 0.01,
-    regularization = RegularizationOptions(enabled = true),   # opt in
 )
+
+alg = RegularizedIntegrator(SymmetricProjectionIntegrator())   # opt in
+sol = solve(prob, alg)
 ```
+
+All keyword arguments below go on the `RegularizedIntegrator(...)` constructor
+itself. Its kwargs mirror [`RegularizationOptions`](@ref) (with `enabled = true`
+set implicitly).
 
 ## Backends
 
@@ -50,12 +56,11 @@ For 3D problems, `:lifted_pair` automatically falls back to `:adaptive_cartesian
 
 ```julia
 # Explicit 3D choice
-prob = HamiltonianProblem(sys, tspan, q0, p0; ...
-    regularization = RegularizationOptions(
-        enabled = true,
-        backend = :adaptive_cartesian,
-    ),
+alg = RegularizedIntegrator(
+    SymmetricProjectionIntegrator();
+    backend = :adaptive_cartesian,
 )
+sol = solve(prob, alg)
 ```
 
 ## Activation hysteresis
@@ -72,13 +77,12 @@ r_off = r_off_factor × min_initial_separation   (default factor: 0.25)
 You can override them directly:
 
 ```julia
-prob = HamiltonianProblem(sys, tspan, q0, p0; ...
-    regularization = RegularizationOptions(
-        enabled = true,
-        r_on    = 0.05,
-        r_off   = 0.10,
-    ),
+alg = RegularizedIntegrator(
+    SymmetricProjectionIntegrator();
+    r_on  = 0.05,
+    r_off = 0.10,
 )
+sol = solve(prob, alg)
 ```
 
 ## Chain mode
@@ -86,7 +90,7 @@ prob = HamiltonianProblem(sys, tspan, q0, p0; ...
 When three or more particles form a connected close-encounter cluster,
 regularization falls back to chain mode (adaptive Cartesian substeps for the
 whole cluster). Chain mode is enabled by default; disable with
-`RegularizationOptions(chain_enabled = false)`.
+`RegularizedIntegrator(...; chain_enabled = false)`.
 
 ## Collision bounce
 
@@ -94,10 +98,21 @@ For head-on (ℓ = 0) collisions between like-charge pairs, a reflection
 boundary can be applied before each macro-step. This avoids the non-regularizable
 ℓ ≠ 0 singularity (where particles reach r = 0 at infinite speed).
 
+Collision bounce is a [`CollisionBounce`](@ref) callback; pass it through the
+`callbacks` kwarg of `solve` (or `init`):
+
 ```julia
-prob = HamiltonianProblem(sys, tspan, q0, p0; ...
-    regularization = RegularizationOptions(collision_bounce_radius = 0.02),  # reflect at r < 0.02
-)
+sol = solve(prob, SymmetricProjectionIntegrator();
+            callbacks = CollisionBounce(0.02))   # reflect at r < 0.02
+```
+
+As a convenience, `RegularizedIntegrator` also accepts a `collision_bounce_radius`
+kwarg and synthesises a matching callback automatically:
+
+```julia
+alg = RegularizedIntegrator(SymmetricProjectionIntegrator();
+                            collision_bounce_radius = 0.02)
+sol = solve(prob, alg)
 ```
 
 Collision bounce works best **without** Levi-Civita regularization (the

--- a/docs/src/zollner.md
+++ b/docs/src/zollner.md
@@ -46,13 +46,17 @@ prob = HamiltonianProblem(
 
 ## Combining with regularization
 
-Zöllner is fully compatible with regularization:
+Zöllner is fully compatible with regularization. Zöllner is a problem-level
+option; regularization is an algorithm wrapper. Combine them by setting
+`zollner` on the problem and wrapping the algorithm:
 
 ```julia
 prob = HamiltonianProblem(sys, tspan, q0, p0; ...
-    zollner        = ZollnerOptions(enabled = true, a = 0.01),
-    regularization = RegularizationOptions(enabled = true),
+    zollner = ZollnerOptions(enabled = true, a = 0.01),
 )
+
+alg = RegularizedIntegrator(SymmetricProjectionIntegrator())
+sol = solve(prob, alg)
 ```
 
 κ values are automatically included in the parameter vector passed to regularization


### PR DESCRIPTION
## Summary
- Phase 5 PR-B. Fix stale docs examples that still showed `regularization = RegularizationOptions(enabled = true)` as a `HamiltonianProblem` kwarg — that kwarg was dropped in Phase 3 when regularization moved onto the algorithm wrapper.
- Collision bounce documented as the `CollisionBounce(radius)` callback (plus the convenience `collision_bounce_radius` kwarg on `RegularizedIntegrator`).
- κ values: replace `HamiltonianProblem.kappas` field references with the `kappas(prob)` accessor.
- Separate problem-level (`ZollnerOptions` via `zollner = …`) vs algorithm-level (`RegularizationOptions` inside `RegularizedIntegrator`) options in the internals "Immutable options pattern" note.

## Test plan
- [x] `julia --project=docs docs/make.jl` builds clean; no missing docstring / broken cross-reference warnings.
- [x] `rg 'regularization\s*=\s*RegularizationOptions|HamiltonianProblem\.kappas' docs/src` returns no matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)