### PR TITLE
docs: prepare release notes for v0.5.0 and refresh CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,10 +58,19 @@ Quick-reference mirror — source of truth: [docs/src/internals.md](docs/src/int
 `params = [m₁…mₙ, q₁…qₙ, c, κ₁₂…κ_{N-1,N}]` — length `2N + 1 + N*(N-1)/2`.
 Direct calls to `dq_dt_compiled`/`dp_dt_compiled` **must** include κ entries (all 1.0 when Zöllner disabled).
 
-### Regularization backends
+### Algorithms and callbacks
 
-Only `:adaptive_cartesian` (2D+3D) and `:lifted_pair` (2D only) are valid.
-Neither backend regularizes Weber's velocity-dependent force.
+Regularization and collision bounce are composed outside the problem:
+
+- **Algorithm wrapper**: `RegularizedIntegrator(SymmetricProjectionIntegrator(); backend=:lifted_pair|:adaptive_cartesian, r_on_factor=..., r_off_factor=..., max_substeps=..., ...)`.
+  Pass to `solve(prob, alg)`.
+- **Callback**: `CollisionBounce(radius)` passed via `solve(prob, alg; callbacks=CollisionBounce(r))`.
+- Regularization backends: `:adaptive_cartesian` (2D+3D) and `:lifted_pair` (2D only). Neither regularizes Weber's velocity-dependent force.
+
+### Accessor API
+
+`HamiltonianProblem` no longer stores `masses`, `charges`, `c`, `kappas`, `regularization`, or `zollner` as fields. Use exported accessors:
+`masses(prob)`, `charges(prob)`, `speed_of_light(prob)`, `kappas(prob)`, `regularization(prob)`, `zollner(prob)`, `params(prob)`, plus `n_particles(sys)`, `dims(sys)` on `HamiltonianSystem`.
 
 ### EnergyStatistics fields
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,6 +1,43 @@
 <!-- Add release notes here before running ./release.sh -->
 <!-- This file is cleared automatically on each release execute -->
 
-### Changed
+### Breaking changes
 
-- Renamed `research/` to `_research/` to signal its exploratory, non-definitive status. Added a top-level banner in `_research/README.md` and cross-referenced the change in `README.md`, `CLAUDE.md`, and `docs/src/internals.md`. No public API or tooling changes.
+This release completes the layered **System → Problem → Algorithm → Callbacks** architectural refactor. The public API is reshaped end-to-end; no deprecation shims are provided.
+
+- **Renamed top-level types.** `WeberSystem` → `HamiltonianSystem`, `WeberProblem` → `HamiltonianProblem`, `WeberSolution` → `HamiltonianSolution`, `WeberIntegrator` → `HamiltonianIntegrator`, `WeberAlgorithm` → `HamiltonianAlgorithm`.
+- **`HamiltonianSystem` is now built from terms.** `HamiltonianSystem(n, dims)` still works (defaults to Weber + Zöllner). A new generic constructor `HamiltonianSystem(H, q, p; params, t)` and term builders `weber_term(...)`, `zollner_term(...)`, `kinetic_term(...)`, `coulomb_term(...)` let users assemble custom Hamiltonians. Each system exposes `system.terms::Vector{NamedTerm}` with per-term `pair_decomposition` closures driving statistics.
+- **`HamiltonianProblem` fields dropped.** `masses`, `charges`, `c`, `kappas`, `regularization`, `zollner` are no longer fields on the problem. Construct with kwargs as before; access via exported accessors: `masses(prob)`, `charges(prob)`, `speed_of_light(prob)`, `kappas(prob)`, `regularization(prob)`, `zollner(prob)`, `params(prob)`, `n_particles(sys)`, `dims(sys)`.
+- **Regularization is now an algorithm wrapper, not a problem option.** Replace `regularization=RegularizationOptions(...)` on `HamiltonianProblem` with `RegularizedIntegrator(SymmetricProjectionIntegrator(); r_on_factor=..., r_off_factor=..., backend=..., ...)` passed to `solve`.
+- **Collision bounce is now a callback.** Replace `regularization=RegularizationOptions(collision_bounce_radius=r)` with `solve(prob, alg; callbacks=CollisionBounce(r))`.
+- **Compiled EOM signature includes `t`.** `dq_dt_compiled(out, q, p, t, params)` and `dp_dt_compiled(out, q, p, t, params)` — direct callers must thread the time argument.
+
+### Added
+
+- `RegularizedIntegrator{BaseAlg}` algorithm wrapper preserving symplectic projection via the base algorithm's `projection_kernel`.
+- `CollisionBounce(radius)` pre-step callback. `CallbackSet(...)` composition.
+- Accessor API on `HamiltonianSystem` and `HamiltonianProblem` to insulate downstream code from struct layout.
+- `NamedTerm{S}` with per-term compiled EOMs and optional `pair_decomposition(i, j, q, p, params)` for pair-wise statistics.
+- Symbolic builders: `weber_term`, `zollner_term`, `kinetic_term`, `coulomb_term`.
+- Regression fixtures (`test/regression/fixtures/*.jld2`) with 1e-12 numerical-equivalence validation across every refactor phase.
+
+### Migration guide
+
+```julia
+# Before
+prob = WeberProblem(sys, (0.0, T), q0, p0;
+    masses=ms, charges=qs, c=1.0,
+    regularization=RegularizationOptions(enabled=true, backend=:lifted_pair,
+                                          collision_bounce_radius=0.02))
+sol = solve(prob, SymmetricProjectionIntegrator())
+
+# After
+prob = HamiltonianProblem(sys, (0.0, T), q0, p0; masses=ms, charges=qs, c=1.0)
+alg  = RegularizedIntegrator(SymmetricProjectionIntegrator(); backend=:lifted_pair)
+sol  = solve(prob, alg; callbacks=CollisionBounce(0.02))
+
+# Field access
+ms  = masses(prob)          # was: prob.masses
+κs  = kappas(prob)          # was: prob.kappas
+n   = n_particles(sys)      # was: sys.n_particles
+```


### PR DESCRIPTION
## Summary
Phase 7 of the architectural refactor — release prep. Writes the v0.5.0 release notes summarising Phase 1-6 breaking changes, and refreshes the Critical Conventions section of CLAUDE.md to document the post-refactor API (algorithm-wrapper regularization, callback-based collision bounce, accessor API).

## Changes
- **RELEASENOTES.md**: Breaking changes section listing the renamed types, term-based `HamiltonianSystem`, dropped problem fields, regularization-as-algorithm-wrapper, collision-bounce-as-callback, and `t`-threaded compiled EOM signature. Includes a before/after migration guide.
- **CLAUDE.md**: Replaced "Regularization backends" section with "Algorithms and callbacks" + "Accessor API" subsections.

## Verification
- `./release.sh minor` dry-run is clean: `0.4.3 → 0.5.0`, all 31 lines of release notes render correctly, no unintended file modifications.
- Docs-only change; no runtime source touched.

## Test plan
- [ ] CI green on macOS / ubuntu / windows / docs / Julia 1.9
- [ ] After merge, Samer runs `./release.sh minor --execute` to cut v0.5.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)