### PR TITLE
CompatHelper: bump compat for JLD2 in [extras] to 0.6, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,9 +22,9 @@ WeberElectrodynamicsPlotsExt = ["Plots", "LaTeXStrings"]
 [compat]
 Aqua = "0.8"
 CommonSolve = "0.2"
-JLD2 = "0.4, 0.5"
-Latexify = "0.16"
+JLD2 = "0.4, 0.5, 0.6"
 LaTeXStrings = "1"
+Latexify = "0.16"
 LinearAlgebra = "1"
 Makie = "0.21, 0.22, 0.23, 0.24"
 Plots = "1"


### PR DESCRIPTION
Opened manually (CompatHelper workflow left the branch without a PR).

Additive compat bump: `JLD2 = "0.4, 0.5"` → `"0.4, 0.5, 0.6"`. JLD2 is test-only (used by regression fixture capture/validate), and the dev manifest already resolves to JLD2 v0.6.4 with the full suite passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)