### PR TITLE
refactor: move κ out of params into HamiltonianProblem.kappas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,10 +53,12 @@ See [docs/src/internals.md](docs/src/internals.md) for per-file descriptions of 
 
 Quick-reference mirror — source of truth: [docs/src/internals.md](docs/src/internals.md).
 
-### Params vector layout
+### Params and κ vector layout
 
-`params = [m₁…mₙ, q₁…qₙ, c, κ₁₂…κ_{N-1,N}]` — length `2N + 1 + N*(N-1)/2`.
-Direct calls to `dq_dt_compiled`/`dp_dt_compiled` **must** include κ entries (all 1.0 when Zöllner disabled).
+`params = [m₁…mₙ, q₁…qₙ, c]` — length `2N + 1`.
+`kappas = [κ₁₂, κ₁₃, …, κ_{N-1,N}]` — length `N*(N-1)/2`, indexed by `_pair_index(i, j, n)`.
+Compiled EOM signature: `dq_dt_compiled(out, q, p, t, params, kappas)` (same for `dp_dt` and `hamiltonian_compiled`). Direct callers **must** pass both; when Zöllner is disabled, `kappas = ones(N*(N-1)÷2)`.
+Per-pair accessor: `kappa(prob, i, j)`.
 
 ### Algorithms and callbacks
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -11,13 +11,15 @@ This release completes the layered **System → Problem → Algorithm → Callba
 - **Regularization is now an algorithm wrapper, not a problem option.** Replace `regularization=RegularizationOptions(...)` on `HamiltonianProblem` with `RegularizedIntegrator(SymmetricProjectionIntegrator(); r_on_factor=..., r_off_factor=..., backend=..., ...)` passed to `solve`.
 - **Collision bounce is now a callback.** Replace `regularization=RegularizationOptions(collision_bounce_radius=r)` with `solve(prob, alg; callbacks=CollisionBounce(r))`.
 - **Compiled EOM signature includes `t`.** `dq_dt_compiled(out, q, p, t, params)` and `dp_dt_compiled(out, q, p, t, params)` — direct callers must thread the time argument.
+- **κ (Zöllner per-pair coupling) removed from `params`.** The parameter vector is now `[m₁…mₙ, q₁…qₙ, c]` (length `2N+1`); κ values live on `HamiltonianProblem.kappas` and are accessed via `kappas(prob)` (same accessor as before, now a direct field read). Compiled EOMs take κ as a separate positional argument: `dq_dt_compiled(out, q, p, t, params, kappas)`, `dp_dt_compiled(out, q, p, t, params, kappas)`, and `hamiltonian_compiled(q, p, t, params, kappas)`. New per-pair accessor `kappa(prob, i, j)` replaces manual `_pair_index` arithmetic in downstream code. Code that spliced κ onto `params` literals, sliced `params[(2N+2):end]`, or called the compiled EOMs directly must be updated.
 
 ### Added
 
 - `RegularizedIntegrator{BaseAlg}` algorithm wrapper preserving symplectic projection via the base algorithm's `projection_kernel`.
 - `CollisionBounce(radius)` pre-step callback. `CallbackSet(...)` composition.
 - Accessor API on `HamiltonianSystem` and `HamiltonianProblem` to insulate downstream code from struct layout.
-- `NamedTerm{S}` with per-term compiled EOMs and optional `pair_decomposition(i, j, q, p, params)` for pair-wise statistics.
+- `NamedTerm{S}` with per-term compiled EOMs and optional `pair_decomposition(i, j, q, p, params, kappas)` for pair-wise statistics.
+- `kappa(prob, i, j)` per-pair accessor, co-located with `_pair_index` in `hamiltonian_system.jl`.
 - Symbolic builders: `weber_term`, `zollner_term`.
 - Regression fixtures (`test/regression/fixtures/*.jld2`) with 1e-12 numerical-equivalence validation across every refactor phase.
 
@@ -38,6 +40,10 @@ sol  = solve(prob, alg; callbacks=CollisionBounce(0.02))
 
 # Field access
 ms  = masses(prob)          # was: prob.masses
-κs  = kappas(prob)          # was: prob.kappas
+κs  = kappas(prob)          # was: prob.kappas (field access; slicing params[tail] no longer works)
+κij = kappa(prob, 1, 2)     # per-pair — preferred over kappas(prob)[_pair_index(...)]
 n   = n_particles(sys)      # was: sys.n_particles
+
+# Direct compiled-EOM calls now take kappas as a separate positional arg
+sys.dp_dt_compiled(out, q, p, t, params(prob), kappas(prob))
 ```

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -52,16 +52,26 @@ Documenter.jl scaffold: `make.jl`, `Project.toml`, `src/` (page sources), `build
 
 ## Internal Conventions
 
-### Params vector layout
+### Params and κ vector layout
 
 ```
-params = [m₁, ..., mₙ, q₁, ..., qₙ, c, κ₁₂, κ₁₃, ..., κ_{N-1,N}]
-length = 2N + 1 + N*(N-1)/2
+params = [m₁, ..., mₙ, q₁, ..., qₙ, c]                     # length 2N + 1
+kappas = [κ₁₂, κ₁₃, ..., κ_{N-1,N}]                         # length N*(N-1)/2
 ```
 
-Any code calling `sys.dq_dt_compiled(out, q, p, t, params)` or `sys.dp_dt_compiled(out, q, p, t, params)` directly **must** include the κ (kappa) entries. When Zöllner is disabled, all κ values are 1.0.
+Compiled EOM signature (all three accept the same 6 positional args):
 
-Pair index: `_pair_index(i, j, n) = (i-1)*(2n-i)÷2 + (j-i)` (1-based, i < j)
+```
+sys.dq_dt_compiled(out, q, p, t, params, kappas)
+sys.dp_dt_compiled(out, q, p, t, params, kappas)
+sys.hamiltonian_compiled(q, p, t, params, kappas)
+```
+
+Any code calling these directly **must** pass both `params` and `kappas`. When Zöllner is disabled, `kappas = ones(N*(N-1)÷2)`. For single-particle systems (no pairs), `kappas = Float64[]`.
+
+On `HamiltonianProblem`, use `kappas(prob)` to obtain the whole vector, or `kappa(prob, i, j)` for a single pair. The latter is preferred over manual `_pair_index` arithmetic in downstream code.
+
+Pair index (internal): `_pair_index(i, j, n) = (i-1)*(2n-i)÷2 + (j-i)` (1-based, i < j)
 
 ### Regularization backends
 

--- a/ext/WeberElectrodynamicsMakieExt.jl
+++ b/ext/WeberElectrodynamicsMakieExt.jl
@@ -11,7 +11,6 @@ using WeberElectrodynamics:
     HamiltonianSolution,
     SymmetricProjectionIntegrator,
     HamiltonianAlgorithm,
-    _pair_index,
     compute_total_kinetic_energy,
     compute_pair_weber_components
 using CommonSolve: init, step!
@@ -110,12 +109,11 @@ function _compute_step_energy(
     c_val = speed_of_light(prob)
     d = dims(prob)
     n = n_particles(prob)
-    κs = kappas(prob)
 
     KE = compute_total_kinetic_energy(p, ms, d)
     PE = 0.0
     for i = 1:n, j = (i+1):n
-        kappa_ij = κs[_pair_index(i, j, n)]
+        kappa_ij = kappa(prob, i, j)
         coulomb, velocity, _, _ =
             compute_pair_weber_components(q, p, i, j, ms, qs, c_val, d, kappa_ij)
         PE += coulomb + velocity

--- a/src/WeberElectrodynamics.jl
+++ b/src/WeberElectrodynamics.jl
@@ -24,7 +24,7 @@ export RegularizationOptions
 export RegularizationDiagnostics
 export ZollnerOptions
 export SymmetricProjectionIntegrator
-export masses, charges, speed_of_light, kappas, params
+export masses, charges, speed_of_light, kappas, kappa, params
 
 # =============================================================================
 # Regularization Helpers

--- a/src/hamiltonian/builders/weber.jl
+++ b/src/hamiltonian/builders/weber.jl
@@ -93,6 +93,7 @@ function _weber_pair_decomposition(
     q::AbstractVector{Float64},
     p::AbstractVector{Float64},
     params::AbstractVector{Float64},
+    kappas::AbstractVector{Float64},
     n_particles::Int,
     dims::Int,
 )
@@ -101,7 +102,7 @@ function _weber_pair_decomposition(
     @inbounds qi = params[n_particles+i]
     @inbounds qj = params[n_particles+j]
     @inbounds c = params[2*n_particles+1]
-    @inbounds κ = params[2*n_particles+1+_pair_index(i, j, n_particles)]
+    @inbounds κ = kappas[_pair_index(i, j, n_particles)]
 
     qi_start = (i - 1) * dims + 1
     qj_start = (j - 1) * dims + 1

--- a/src/hamiltonian/builders/zollner.jl
+++ b/src/hamiltonian/builders/zollner.jl
@@ -91,6 +91,7 @@ function _zollner_pair_decomposition(
     q::AbstractVector{Float64},
     p::AbstractVector{Float64},
     params::AbstractVector{Float64},
+    kappas::AbstractVector{Float64},
     n_particles::Int,
     dims::Int,
 )
@@ -99,7 +100,7 @@ function _zollner_pair_decomposition(
     @inbounds qi = params[n_particles+i]
     @inbounds qj = params[n_particles+j]
     @inbounds c = params[2*n_particles+1]
-    @inbounds κ = params[2*n_particles+1+_pair_index(i, j, n_particles)]
+    @inbounds κ = kappas[_pair_index(i, j, n_particles)]
 
     qi_start = (i - 1) * dims + 1
     qj_start = (j - 1) * dims + 1

--- a/src/hamiltonian_system.jl
+++ b/src/hamiltonian_system.jl
@@ -20,19 +20,20 @@ and code generation via Symbolics.jl; expect a few seconds for the first call.
 - `p_symbols::Vector{Num}`: Symbolic momentum variables `[px1, py1, ...]`.
 - `t_symbol::Num`: Symbolic time variable. Reserved for time-dependent terms;
   the current Weber Hamiltonian is autonomous and does not use it.
-- `param_symbols`: Symbolic parameter vector `[m1…mN, q1…qN, c, κ12, κ13, …]`.
+- `param_symbols`: Symbolic parameter vector `[m1…mN, q1…qN, c]`.
+- `kappa_symbols`: Symbolic κ vector `[κ12, κ13, …, κ_{N-1,N}]`, length `N*(N-1)/2`.
 - `hamiltonian_symbolic`: Full symbolic Weber Hamiltonian expression.
 - `dq_dt_symbolic`, `dp_dt_symbolic`: Symbolic Hamilton's equations.
-- `dq_dt_compiled(out, q, p, t, params)`, `dp_dt_compiled(out, q, p, t, params)`:
+- `dq_dt_compiled(out, q, p, t, params, kappas)`, `dp_dt_compiled(out, q, p, t, params, kappas)`:
   In-place compiled equations of motion. `t` is currently unused.
-- `hamiltonian_compiled(q, p, t, params)`: Compiled scalar Hamiltonian function.
+- `hamiltonian_compiled(q, p, t, params, kappas)`: Compiled scalar Hamiltonian function.
 - `degrees_of_freedom::Int`: Total DOF = `n_particles × dims`.
 - `terms::Vector{NamedTerm}`: Named components of the Hamiltonian (e.g.
   `:weber`, `:zollner`) preserving the decomposition for per-term statistics
   and plotting. The generic constructor assigns a single `:hamiltonian` term
   by default; specialized constructors populate richer decompositions.
 """
-struct HamiltonianSystem{H,QD,PD,QF,PF,HF,PS,TS<:AbstractVector{<:NamedTerm}}
+struct HamiltonianSystem{H,QD,PD,QF,PF,HF,PS,KS,TS<:AbstractVector{<:NamedTerm}}
     n_particles::Int
     dims::Int
 
@@ -40,6 +41,7 @@ struct HamiltonianSystem{H,QD,PD,QF,PF,HF,PS,TS<:AbstractVector{<:NamedTerm}}
     p_symbols::Vector{Num}
     t_symbol::Num
     param_symbols::PS
+    kappa_symbols::KS
 
     hamiltonian_symbolic::H
     dq_dt_symbolic::QD
@@ -93,15 +95,15 @@ include("hamiltonian/builders/basic.jl")
 
 """
     HamiltonianSystem(H, q_vars, p_vars;
-                      param_symbols, t, n_particles, dims) -> HamiltonianSystem
+                      param_symbols, kappa_symbols, t, n_particles, dims) -> HamiltonianSystem
 
 Generic constructor from a pre-built symbolic Hamiltonian `H`.
 
 Derives Hamilton's equations analytically via `Symbolics.derivative`, then
 compiles them to in-place Julia functions with
-`Symbolics.build_function(…, q_vars, p_vars, t, param_symbols)`. The signature
-of the compiled EOMs is `(out, q, p, t, params)`; `t` is presently unused but
-reserved for time-dependent terms.
+`Symbolics.build_function(…, q_vars, p_vars, t, param_symbols, kappa_symbols)`.
+The signature of the compiled EOMs is `(out, q, p, t, params, kappas)`;
+`t` is presently unused but reserved for time-dependent terms.
 
 Use this overload to build a custom Hamiltonian (e.g. `H = weber_term(…) +
 zollner_term(…)`). For the default pure Weber case, the convenience constructor
@@ -112,7 +114,9 @@ zollner_term(…)`). For the default pure Weber case, the convenience constructo
 - `q_vars`, `p_vars`: Phase-space symbolic variables, each length `n_particles*dims`.
 
 # Keywords
-- `param_symbols`: Symbolic parameter vector passed to `build_function`.
+- `param_symbols`: Symbolic parameter vector `[m1…mN, q1…qN, c]`.
+- `kappa_symbols`: Symbolic per-pair κ vector. Pass `[]` (empty) if `H` has no
+  κ dependence; otherwise length `N*(N-1)/2`.
 - `t`: Symbolic time variable (reserved; may be unused).
 - `n_particles::Int`, `dims::Int`: Problem shape.
 - `terms`: Optional `Vector{NamedTerm}` naming the components of `H`. If
@@ -124,6 +128,7 @@ function HamiltonianSystem(
     q_vars::AbstractVector,
     p_vars::AbstractVector;
     param_symbols::AbstractVector,
+    kappa_symbols::AbstractVector = Num[],
     t,
     n_particles::Int,
     dims::Int,
@@ -138,6 +143,7 @@ function HamiltonianSystem(
         p_vars,
         t,
         param_symbols,
+        kappa_symbols,
         expression = Val{false},
     )[2]
     dp_dt_compiled = Symbolics.build_function(
@@ -146,6 +152,7 @@ function HamiltonianSystem(
         p_vars,
         t,
         param_symbols,
+        kappa_symbols,
         expression = Val{false},
     )[2]
     hamiltonian_compiled = Symbolics.build_function(
@@ -154,6 +161,7 @@ function HamiltonianSystem(
         p_vars,
         t,
         param_symbols,
+        kappa_symbols,
         expression = Val{false},
     )
 
@@ -168,6 +176,7 @@ function HamiltonianSystem(
         p_vars,
         t,
         param_symbols,
+        kappa_symbols,
         H,
         dq_dt_symbolic,
         dp_dt_symbolic,
@@ -207,7 +216,7 @@ function HamiltonianSystem(n_particles::Int, dims::Int)
 
     t_var = Symbolics.variable(:t)
 
-    param_symbols = vcat(m_vars, charge_vars, [c_var], kappa_vars)
+    param_symbols = vcat(m_vars, charge_vars, [c_var])
 
     # Decompose into additive terms:
     #   H_weber  = pure Weber (κ ≡ 1) — kinetic + Σ q_i q_j / r · (1 − ṙ²/2c²)
@@ -240,17 +249,18 @@ function HamiltonianSystem(n_particles::Int, dims::Int)
     H = weber_H + zollner_H
 
     weber_decomp =
-        (i, j, q, p, params) ->
-            _weber_pair_decomposition(i, j, q, p, params, n_particles, dims)
+        (i, j, q, p, params, kappas) ->
+            _weber_pair_decomposition(i, j, q, p, params, kappas, n_particles, dims)
     zollner_decomp =
-        (i, j, q, p, params) ->
-            _zollner_pair_decomposition(i, j, q, p, params, n_particles, dims)
+        (i, j, q, p, params, kappas) ->
+            _zollner_pair_decomposition(i, j, q, p, params, kappas, n_particles, dims)
 
     return HamiltonianSystem(
         H,
         q_vars,
         p_vars;
         param_symbols = param_symbols,
+        kappa_symbols = kappa_vars,
         t = t_var,
         n_particles = n_particles,
         dims = dims,

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -8,6 +8,7 @@ using LinearAlgebra: norm, mul!, Transpose
     dq_dt_compiled,
     dp_dt_compiled,
     params::Vector{Float64},
+    kappas::Vector{Float64},
     auxiliary_position_buffer::Vector{Float64},
     momentum_buffer::Vector{Float64},
     position_buffer::Vector{Float64},
@@ -29,22 +30,22 @@ using LinearAlgebra: norm, mul!, Transpose
         P_component = Z_vec[idx_P_start:idx_P_end]
         Y_component = Z_vec[idx_Y_start:idx_Y_end]
 
-        dq_dt_compiled(auxiliary_position_buffer, Q_component, Y_component, t, params)
-        dp_dt_compiled(momentum_buffer, Q_component, Y_component, t, params)
+        dq_dt_compiled(auxiliary_position_buffer, Q_component, Y_component, t, params, kappas)
+        dp_dt_compiled(momentum_buffer, Q_component, Y_component, t, params, kappas)
 
         @. X_component = X_component + auxiliary_position_buffer * (dt / 2)
         @. P_component = P_component + momentum_buffer * (dt / 2)
 
         t_mid = t + dt / 2
-        dq_dt_compiled(position_buffer, X_component, P_component, t_mid, params)
-        dp_dt_compiled(auxiliary_momentum_buffer, X_component, P_component, t_mid, params)
+        dq_dt_compiled(position_buffer, X_component, P_component, t_mid, params, kappas)
+        dp_dt_compiled(auxiliary_momentum_buffer, X_component, P_component, t_mid, params, kappas)
 
         @. Q_component = Q_component + position_buffer * dt
         @. Y_component = Y_component + auxiliary_momentum_buffer * dt
 
         t_end = t + dt
-        dq_dt_compiled(auxiliary_position_buffer, Q_component, Y_component, t_end, params)
-        dp_dt_compiled(momentum_buffer, Q_component, Y_component, t_end, params)
+        dq_dt_compiled(auxiliary_position_buffer, Q_component, Y_component, t_end, params, kappas)
+        dp_dt_compiled(momentum_buffer, Q_component, Y_component, t_end, params, kappas)
 
         @. X_component = X_component + auxiliary_position_buffer * (dt / 2)
         @. P_component = P_component + momentum_buffer * (dt / 2)
@@ -66,6 +67,7 @@ end
     dq_dt_compiled,
     dp_dt_compiled,
     params::Vector{Float64},
+    kappas::Vector{Float64},
     auxiliary_position_buffer::Vector{Float64},
     momentum_buffer::Vector{Float64},
     position_buffer::Vector{Float64},
@@ -82,6 +84,7 @@ end
             dq_dt_compiled,
             dp_dt_compiled,
             params,
+            kappas,
             auxiliary_position_buffer,
             momentum_buffer,
             position_buffer,
@@ -109,6 +112,7 @@ end
     dq_dt_compiled = prob.system.dq_dt_compiled
     dp_dt_compiled = prob.system.dp_dt_compiled
     params = prob.params
+    kappas = prob.kappas
 
     d = buffers.d
 
@@ -150,6 +154,7 @@ end
             dq_dt_compiled,
             dp_dt_compiled,
             params,
+            kappas,
             auxiliary_position_buffer,
             momentum_buffer,
             position_buffer,
@@ -176,6 +181,7 @@ end
                 dq_dt_compiled,
                 dp_dt_compiled,
                 params,
+                kappas,
                 auxiliary_position_buffer,
                 momentum_buffer,
                 position_buffer,
@@ -202,6 +208,7 @@ end
         dq_dt_compiled,
         dp_dt_compiled,
         params,
+        kappas,
         auxiliary_position_buffer,
         momentum_buffer,
         position_buffer,
@@ -224,6 +231,7 @@ end
             dq_dt_compiled,
             dp_dt_compiled,
             params,
+            kappas,
             auxiliary_position_buffer,
             momentum_buffer,
             position_buffer,
@@ -335,6 +343,7 @@ end
 )
     n = rb.n_particles
     params_pair = rb.params_pair
+    kappas_pair = rb.kappas_pair
     ms = masses(prob)
     qs = charges(prob)
     κs = kappas(prob)
@@ -347,11 +356,12 @@ end
         params_pair[n+i] = qs[i]
         params_pair[n+j] = qs[j]
         params_pair[2n+1] = speed_of_light(prob)
-        # Copy kappas; charges for non-(i,j) pairs are zero so their κ values
-        # do not affect the force, but the buffer must have the right length.
+        # Copy κ vector; charges for non-(i,j) pairs are zero so their κ
+        # values do not affect the force, but the buffer must have the right
+        # length to match the compiled EOM's expectation.
         n_pairs = rb.n_pairs
         for k = 1:n_pairs
-            params_pair[2n+1+k] = κs[k]
+            kappas_pair[k] = κs[k]
         end
     end
 
@@ -366,10 +376,10 @@ end
     prob::HamiltonianProblem,
 )
     system = prob.system
-    system.dq_dt_compiled(rb.dq_full, q_state, p_state, t, prob.params)
-    system.dp_dt_compiled(rb.dp_full, q_state, p_state, t, prob.params)
-    system.dq_dt_compiled(rb.dq_pair, q_state, p_state, t, rb.params_pair)
-    system.dp_dt_compiled(rb.dp_pair, q_state, p_state, t, rb.params_pair)
+    system.dq_dt_compiled(rb.dq_full, q_state, p_state, t, prob.params, prob.kappas)
+    system.dp_dt_compiled(rb.dp_full, q_state, p_state, t, prob.params, prob.kappas)
+    system.dq_dt_compiled(rb.dq_pair, q_state, p_state, t, rb.params_pair, rb.kappas_pair)
+    system.dp_dt_compiled(rb.dp_pair, q_state, p_state, t, rb.params_pair, rb.kappas_pair)
 
     @inbounds @. rb.dq_ext = rb.dq_full - rb.dq_pair
     @inbounds @. rb.dp_ext = rb.dp_full - rb.dp_pair
@@ -647,8 +657,8 @@ end
     prev_u2 = rb.lc_u[2]
     prev_u_norm2 = prev_u1 * prev_u1 + prev_u2 * prev_u2
 
-    system.dq_dt_compiled(rb.dq_pair, q, p, t, rb.params_pair)
-    system.dp_dt_compiled(rb.dp_pair, q, p, t, rb.params_pair)
+    system.dq_dt_compiled(rb.dq_pair, q, p, t, rb.params_pair, rb.kappas_pair)
+    system.dp_dt_compiled(rb.dp_pair, q, p, t, rb.params_pair, rb.kappas_pair)
 
     mi, mj, mu, M = _extract_pair_2d_state!(rb, q, p, ms, i, j)
     _extract_pair_2d_derivatives!(rb, rb.dq_pair, rb.dp_pair, i, j, mi, mj, mu, M)
@@ -708,8 +718,8 @@ end
     )
 
     t_mid = t + dt_sub * 0.5
-    system.dq_dt_compiled(rb.dq_pair, rb.q_mid, rb.p_mid, t_mid, rb.params_pair)
-    system.dp_dt_compiled(rb.dp_pair, rb.q_mid, rb.p_mid, t_mid, rb.params_pair)
+    system.dq_dt_compiled(rb.dq_pair, rb.q_mid, rb.p_mid, t_mid, rb.params_pair, rb.kappas_pair)
+    system.dp_dt_compiled(rb.dp_pair, rb.q_mid, rb.p_mid, t_mid, rb.params_pair, rb.kappas_pair)
     _extract_pair_2d_derivatives!(rb, rb.dq_pair, rb.dp_pair, i, j, mi, mj, mu, M)
 
     _compute_lc_tau_derivatives!(

--- a/src/statistics/energy.jl
+++ b/src/statistics/energy.jl
@@ -284,7 +284,7 @@ function compute_energy_timeseries(
     pair_energies = sizehint!(Dict{Tuple{Int,Int},PairEnergyData}(), n_pairs)
     for i = 1:n
         for j = (i+1):n
-            kappa_ij = κs[_pair_index(i, j, n)]
+            kappa_ij = kappa(prob, i, j)
             pair_energies[(i, j)] = PairEnergyData(
                 (i, j),
                 kappa_ij,
@@ -317,8 +317,8 @@ function compute_energy_timeseries(
         zollner_sum = 0.0
         for i = 1:n
             for j = (i+1):n
-                wc = weber_decomp(i, j, q, p, params_vec)
-                zc = zollner_decomp(i, j, q, p, params_vec)
+                wc = weber_decomp(i, j, q, p, params_vec, κs)
+                zc = zollner_decomp(i, j, q, p, params_vec, κs)
                 coulomb = wc.coulomb
                 velocity = wc.velocity
                 rdot = wc.rdot
@@ -338,7 +338,7 @@ function compute_energy_timeseries(
         total_zollner_residual[pt_idx] = zollner_sum
 
         # Validate against compiled Hamiltonian
-        H_compiled = hamiltonian_compiled(q, p, t_pt, params_vec)
+        H_compiled = hamiltonian_compiled(q, p, t_pt, params_vec, κs)
         hamiltonian_validation[pt_idx] = abs(total_energy[pt_idx] - H_compiled)
     end
 

--- a/src/statistics/forces.jl
+++ b/src/statistics/forces.jl
@@ -249,7 +249,7 @@ function compute_pair_force_timeseries(
     k = charges[i] * charges[j]
 
     # Zöllner coupling for this pair (1.0 = standard Weber)
-    kappa_ij = kappas(sol.prob)[_pair_index(i, j, n_particles)]
+    kappa_ij = kappa(sol.prob, i, j)
 
     zollner_extra_magnitude = Vector{Float64}(undef, n_force_steps)
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -332,6 +332,7 @@ mutable struct RegularizationBuffers
     ks_n::Vector{Float64}
 
     params_pair::Vector{Float64}
+    kappas_pair::Vector{Float64}
     dq_full::Vector{Float64}
     dp_full::Vector{Float64}
     dq_pair::Vector{Float64}
@@ -413,7 +414,8 @@ mutable struct RegularizationBuffers
             Vector{Float64}(undef, 4),
             Matrix{Float64}(undef, 3, 4),
             Vector{Float64}(undef, 4),
-            Vector{Float64}(undef, 2n_particles + 1 + n_pairs),
+            Vector{Float64}(undef, 2n_particles + 1),
+            Vector{Float64}(undef, n_pairs),
             Vector{Float64}(undef, dof),
             Vector{Float64}(undef, dof),
             Vector{Float64}(undef, dof),
@@ -449,7 +451,7 @@ and solver/regularization options into a single immutable structure.
 - `maximum_iterations=100`: Maximum projection iterations per step.
 - `zollner=ZollnerOptions()`: Zöllner electrogravitational extension options.
   See `ZollnerOptions` for all available fields. The options are used at
-  construction time to compute the per-pair `κ` values packed into `params`
+  construction time to compute the per-pair `κ` values stored in `prob.kappas`
   and are **not** retained on the problem; inspect κ via `kappas(prob)`.
 
 Regularization options moved to [`RegularizedIntegrator`](@ref); pass them via
@@ -459,8 +461,10 @@ Regularization options moved to [`RegularizedIntegrator`](@ref); pass them via
 - `system::HamiltonianSystem`: Compiled Hamiltonian system.
 - `tspan::Tuple{Float64,Float64}`: Integration interval.
 - `q_initial`, `p_initial::Vector{Float64}`: Initial phase-space point.
-- `params::Vector{Float64}`: Packed parameter vector `[masses; charges; c; kappas]`.
-  Access slices via the `masses`, `charges`, `speed_of_light`, `kappas` accessors.
+- `params::Vector{Float64}`: Packed parameter vector `[masses; charges; c]`,
+  length `2N + 1`. Access slices via `masses`, `charges`, `speed_of_light`.
+- `kappas::Vector{Float64}`: Per-pair Zöllner coupling `[κ₁₂, κ₁₃, …]`,
+  length `N*(N-1)/2`. All entries `1.0` when Zöllner is disabled.
 - `dt::Float64`: Fixed step size.
 - `convergence_tolerance::Float64`: Projection convergence threshold.
 - `maximum_iterations::Int`: Maximum projection iterations per step.
@@ -471,6 +475,7 @@ struct HamiltonianProblem
     q_initial::Vector{Float64}
     p_initial::Vector{Float64}
     params::Vector{Float64}
+    kappas::Vector{Float64}
     dt::Float64
     convergence_tolerance::Float64
     maximum_iterations::Int
@@ -506,7 +511,7 @@ struct HamiltonianProblem
         c_f64 = Float64(c)
 
         kappas = _compute_zollner_kappas(charges_f64, zollner, n_particles)
-        params = vcat(masses_f64, charges_f64, [c_f64], kappas)
+        params = vcat(masses_f64, charges_f64, [c_f64])
 
         new(
             system,
@@ -514,9 +519,37 @@ struct HamiltonianProblem
             Vector{Float64}(q_initial),
             Vector{Float64}(p_initial),
             params,
+            kappas,
             Float64(dt),
             Float64(convergence_tolerance),
             Int(maximum_iterations),
+        )
+    end
+
+    # Internal constructor used by _with_tspan to clone a problem while
+    # preserving the already-packed params and κ vectors. Not part of the
+    # public API.
+    function HamiltonianProblem(
+        system::HamiltonianSystem,
+        tspan::Tuple{Float64,Float64},
+        q_initial::Vector{Float64},
+        p_initial::Vector{Float64},
+        params::Vector{Float64},
+        kappas::Vector{Float64},
+        dt::Float64,
+        convergence_tolerance::Float64,
+        maximum_iterations::Int,
+    )
+        new(
+            system,
+            tspan,
+            q_initial,
+            p_initial,
+            params,
+            kappas,
+            dt,
+            convergence_tolerance,
+            maximum_iterations,
         )
     end
 end
@@ -527,12 +560,13 @@ end
     masses(prob::HamiltonianProblem) -> AbstractVector{Float64}
     charges(prob::HamiltonianProblem) -> AbstractVector{Float64}
     speed_of_light(prob::HamiltonianProblem) -> Float64
-    kappas(prob::HamiltonianProblem) -> AbstractVector{Float64}
+    kappas(prob::HamiltonianProblem) -> Vector{Float64}
     params(prob::HamiltonianProblem) -> Vector{Float64}
 
-Read-only accessors. `masses`, `charges`, and `kappas` return views into the
-backing `params` vector (layout `[m₁…mₙ, q₁…qₙ, c, κ…]`), so they are O(1)
-and allocation-free but must be treated as read-only.
+Read-only accessors. `masses` and `charges` return views into the backing
+`params` vector (layout `[m₁…mₙ, q₁…qₙ, c]`); `kappas` returns the backing
+`κ` vector directly. All are O(1) and allocation-free but must be treated
+as read-only.
 """
 n_particles(prob::HamiltonianProblem) = n_particles(prob.system)
 dims(prob::HamiltonianProblem) = dims(prob.system)
@@ -540,24 +574,32 @@ masses(prob::HamiltonianProblem) = @view prob.params[1:n_particles(prob)]
 charges(prob::HamiltonianProblem) =
     @view prob.params[(n_particles(prob)+1):(2*n_particles(prob))]
 speed_of_light(prob::HamiltonianProblem) = prob.params[2*n_particles(prob)+1]
-kappas(prob::HamiltonianProblem) = @view prob.params[(2*n_particles(prob)+2):end]
+kappas(prob::HamiltonianProblem) = prob.kappas
 params(prob::HamiltonianProblem) = prob.params
 
+"""
+    kappa(prob::HamiltonianProblem, i::Int, j::Int) -> Float64
+
+Return the Zöllner coupling `κ_ij` for pair `(i, j)` with `i < j`.
+"""
+kappa(prob::HamiltonianProblem, i::Int, j::Int) =
+    prob.kappas[_pair_index(i, j, n_particles(prob))]
+
 # Internal: clone a problem with an overridden tspan while preserving the
-# compiled system, initial conditions, and packed params (including any
-# Zöllner-derived κ values). Used by the Makie streaming animation to extend
-# the integration horizon without needing to re-derive the construction inputs.
+# compiled system, initial conditions, packed params, and κ vector. Used by
+# the Makie streaming animation to extend the integration horizon without
+# needing to re-derive the construction inputs.
 function _with_tspan(prob::HamiltonianProblem, tspan::Tuple{Real,Real})
     return HamiltonianProblem(
         prob.system,
-        prob.tspan,
-        prob.q_initial,
-        prob.p_initial,
+        (Float64(tspan[1]), Float64(tspan[2])),
+        copy(prob.q_initial),
+        copy(prob.p_initial),
         copy(prob.params),
+        copy(prob.kappas),
         prob.dt,
         prob.convergence_tolerance,
         prob.maximum_iterations,
-        (Float64(tspan[1]), Float64(tspan[2])),
     )
 end
 

--- a/test/test_accessors.jl
+++ b/test/test_accessors.jl
@@ -26,12 +26,17 @@
         @test speed_of_light(prob) == 10.0
         @test kappas(prob) == ones(3)
 
-        # params layout: [m₁…mₙ, q₁…qₙ, c, κ₁₂, κ₁₃, κ₂₃]
-        @test length(params(prob)) == 2*3 + 1 + 3
+        # params layout: [m₁…mₙ, q₁…qₙ, c]; kappas stored separately
+        @test length(params(prob)) == 2*3 + 1
         @test params(prob)[1:3] == masses(prob)
         @test params(prob)[4:6] == charges(prob)
         @test params(prob)[7] == speed_of_light(prob)
-        @test params(prob)[8:10] == kappas(prob)
+        @test length(kappas(prob)) == 3
+
+        # kappa(prob, i, j) per-pair accessor
+        @test kappa(prob, 1, 2) == 1.0
+        @test kappa(prob, 1, 3) == 1.0
+        @test kappa(prob, 2, 3) == 1.0
     end
 
     @testset "zollner injects κ accessor" begin

--- a/test/test_builders.jl
+++ b/test/test_builders.jl
@@ -3,12 +3,13 @@
         # Building via the generic ctor on weber_term output must yield the
         # same compiled EOMs as the convenience ctor (same symbolic expression).
         sys_conv = HamiltonianSystem(2, 2)
-        params = [1.0, 1.0, 1.0, -1.0, 100.0, 1.0]  # m1, m2, q1, q2, c, κ12
+        params = [1.0, 1.0, 1.0, -1.0, 100.0]  # m1, m2, q1, q2, c
+        kappas = [1.0]                         # κ12
         q0 = [1.0, 0.0, -1.0, 0.0]
         p0 = [0.0, 0.1, 0.0, -0.1]
 
         out_conv = zeros(4)
-        sys_conv.dp_dt_compiled(out_conv, q0, p0, 0.0, params)
+        sys_conv.dp_dt_compiled(out_conv, q0, p0, 0.0, params, kappas)
 
         # Sanity: attractive Coulomb, equal & opposite forces
         @test out_conv[1] < 0  # particle 1 pulled in −x
@@ -26,7 +27,7 @@
         m_syms = [m1, m2, m3]
         q_charge_syms = [q1, q2, q3]
         kappa_syms = [k12, k13, k23]
-        param_syms = vcat(m_syms, q_charge_syms, [cc], kappa_syms)
+        param_syms = vcat(m_syms, q_charge_syms, [cc])
 
         H_full = weber_term(
             q_syms,
@@ -64,6 +65,7 @@
             q_syms,
             p_syms;
             param_symbols = param_syms,
+            kappa_symbols = kappa_syms,
             t = tt,
             n_particles = 3,
             dims = 2,
@@ -73,6 +75,7 @@
             q_syms,
             p_syms;
             param_symbols = param_syms,
+            kappa_symbols = kappa_syms,
             t = tt,
             n_particles = 3,
             dims = 2,
@@ -80,18 +83,19 @@
 
         q0 = [0.0, 0.0, 1.0, 0.0, 0.0, 1.0]
         p0 = [0.1, 0.2, -0.1, 0.0, 0.0, -0.2]
-        pvals = [1.0, 1.0, 0.5, 1.0, -1.0, 0.5, 10.0, 1.3, 1.3, 1.0]
+        pvals = [1.0, 1.0, 0.5, 1.0, -1.0, 0.5, 10.0]  # 3 masses + 3 charges + c
+        kvals = [1.3, 1.3, 1.0]                        # κ12, κ13, κ23
 
         outA = zeros(6);
         outB = zeros(6)
-        sys_full.dp_dt_compiled(outA, q0, p0, 0.0, pvals)
-        sys_comp.dp_dt_compiled(outB, q0, p0, 0.0, pvals)
+        sys_full.dp_dt_compiled(outA, q0, p0, 0.0, pvals, kvals)
+        sys_comp.dp_dt_compiled(outB, q0, p0, 0.0, pvals, kvals)
         @test maximum(abs.(outA .- outB)) < 1e-14
 
         outA .= 0;
         outB .= 0
-        sys_full.dq_dt_compiled(outA, q0, p0, 0.0, pvals)
-        sys_comp.dq_dt_compiled(outB, q0, p0, 0.0, pvals)
+        sys_full.dq_dt_compiled(outA, q0, p0, 0.0, pvals, kvals)
+        sys_comp.dq_dt_compiled(outB, q0, p0, 0.0, pvals, kvals)
         @test maximum(abs.(outA .- outB)) < 1e-14
     end
 
@@ -139,9 +143,10 @@
         q0 = [0.3, -0.4, 1.1, 0.7]
         p0 = [0.2, -0.1, 0.05, 0.4]
         pvals = [m1v, m2v]
+        kvals = Float64[]
 
         out_q = zeros(4)
-        sys.dq_dt_compiled(out_q, q0, p0, 0.0, pvals)
+        sys.dq_dt_compiled(out_q, q0, p0, 0.0, pvals, kvals)
         @test isapprox(
             out_q,
             [p0[1] / m1v, p0[2] / m1v, p0[3] / m2v, p0[4] / m2v];
@@ -149,7 +154,7 @@
         )
 
         out_p = zeros(4)
-        sys.dp_dt_compiled(out_p, q0, p0, 0.0, pvals)
+        sys.dp_dt_compiled(out_p, q0, p0, 0.0, pvals, kvals)
         @test all(iszero, out_p)
     end
 
@@ -180,9 +185,10 @@
         q0 = [-1.0, 0.0, 1.0, 0.0]
         p0 = [0.0, 0.3, 0.0, -0.3]
         pvals = [1.0, 1.0, 1.0, -1.0]
+        kvals = Float64[]
 
         out_p = zeros(4)
-        sys.dp_dt_compiled(out_p, q0, p0, 0.0, pvals)
+        sys.dp_dt_compiled(out_p, q0, p0, 0.0, pvals, kvals)
 
         # Attraction: particle 1 pulled +x, particle 2 pulled −x.
         @test out_p[1] > 0
@@ -244,19 +250,20 @@
         p_zero = zeros(6)
         pvals_kc = [1.0, 1.0, 0.5, 1.0, -1.0, 0.5]
         pvals_w = vcat(pvals_kc, [10.0])  # any finite c works at p = 0
+        kvals_empty = Float64[]
 
         out_kc = zeros(6);
         out_w = zeros(6)
-        sys_kc.dp_dt_compiled(out_kc, q0, p_zero, 0.0, pvals_kc)
-        sys_w.dp_dt_compiled(out_w, q0, p_zero, 0.0, pvals_w)
+        sys_kc.dp_dt_compiled(out_kc, q0, p_zero, 0.0, pvals_kc, kvals_empty)
+        sys_w.dp_dt_compiled(out_w, q0, p_zero, 0.0, pvals_w, kvals_empty)
         @test maximum(abs.(out_kc .- out_w)) < 1e-14
 
         # dq/dt differs trivially (pᵢ/mᵢ vs weber's identical expression) but
         # should also agree exactly at p = 0 (both identically zero).
         out_kc .= 0;
         out_w .= 0
-        sys_kc.dq_dt_compiled(out_kc, q0, p_zero, 0.0, pvals_kc)
-        sys_w.dq_dt_compiled(out_w, q0, p_zero, 0.0, pvals_w)
+        sys_kc.dq_dt_compiled(out_kc, q0, p_zero, 0.0, pvals_kc, kvals_empty)
+        sys_w.dq_dt_compiled(out_w, q0, p_zero, 0.0, pvals_w, kvals_empty)
         @test maximum(abs.(out_kc .- out_w)) < 1e-14
     end
 end

--- a/test/test_hamiltonian_system.jl
+++ b/test/test_hamiltonian_system.jl
@@ -21,8 +21,9 @@ using WeberElectrodynamics: _pair_index
         c = 1000.0  # Large c to make Weber ≈ Coulomb
 
         system = HamiltonianSystem(2, 2)
-        # params = [m1, m2, q1, q2, c, κ₁₂]; κ=1 (Zöllner disabled)
-        params = [m1, m2, q1, q2, c, 1.0]
+        # params = [m1, m2, q1, q2, c]; kappas = [κ₁₂], κ=1 (Zöllner disabled)
+        params = [m1, m2, q1, q2, c]
+        kappas = [1.0]
 
         # Test at specific point: particles at x = ±1, no y offset
         q = [1.0, 0.0, -1.0, 0.0]  # particles at x=1 and x=-1
@@ -30,8 +31,8 @@ using WeberElectrodynamics: _pair_index
 
         out_q = zeros(4)
         out_p = zeros(4)
-        system.dq_dt_compiled(out_q, q, p, 0.0, params)
-        system.dp_dt_compiled(out_p, q, p, 0.0, params)
+        system.dq_dt_compiled(out_q, q, p, 0.0, params, kappas)
+        system.dp_dt_compiled(out_p, q, p, 0.0, params, kappas)
 
         # dq/dt = ∂H/∂p ≈ p/m (Weber correction is small for large c)
         @test out_q[1] ≈ p[1] / m1 atol = 1e-6  # px1/m1
@@ -55,9 +56,10 @@ using WeberElectrodynamics: _pair_index
         @test sys1d.degrees_of_freedom == 2
         @test length(sys1d.dq_dt_symbolic) == 2
 
-        params1d = [1.0, 1.0, 1.0, -1.0, 1.0, 1.0]  # m1, m2, q1, q2, c, κ₁₂
+        params1d = [1.0, 1.0, 1.0, -1.0, 1.0]  # m1, m2, q1, q2, c
+        kappas1d = [1.0]                       # κ₁₂
         out1 = zeros(2)
-        sys1d.dq_dt_compiled(out1, [1.0, -1.0], [0.5, -0.5], 0.0, params1d)
+        sys1d.dq_dt_compiled(out1, [1.0, -1.0], [0.5, -0.5], 0.0, params1d, kappas1d)
         # Weber's velocity-dependent potential affects dq/dt, so we just verify
         # the function runs and produces finite output of correct dimension
         @test length(out1) == 2
@@ -79,8 +81,9 @@ using WeberElectrodynamics: _pair_index
         @test sys3body.degrees_of_freedom == 6
         @test sys3body.n_particles == 3
 
-        # params: [m1, m2, m3, q1, q2, q3, c, κ₁₂, κ₁₃, κ₂₃]; all κ=1 (Zöllner disabled)
-        params3 = [1.0, 1.0, 1.0, 1.0, -1.0, 0.5, 1.0, 1.0, 1.0, 1.0]
+        # params: [m1, m2, m3, q1, q2, q3, c]; kappas: [κ₁₂, κ₁₃, κ₂₃]; all κ=1 (Zöllner disabled)
+        params3 = [1.0, 1.0, 1.0, 1.0, -1.0, 0.5, 1.0]
+        kappas3 = [1.0, 1.0, 1.0]
 
         # Should have 3 pairwise interactions in the Hamiltonian
         out_q = zeros(6)
@@ -89,8 +92,8 @@ using WeberElectrodynamics: _pair_index
         p = zeros(6)
 
         # Should run without error
-        sys3body.dq_dt_compiled(out_q, q, p, 0.0, params3)
-        sys3body.dp_dt_compiled(out_p, q, p, 0.0, params3)
+        sys3body.dq_dt_compiled(out_q, q, p, 0.0, params3, kappas3)
+        sys3body.dp_dt_compiled(out_p, q, p, 0.0, params3, kappas3)
     end
 
     @testset "Single particle system" begin
@@ -99,13 +102,14 @@ using WeberElectrodynamics: _pair_index
         @test sys1.degrees_of_freedom == 2
 
         params1 = [2.0, 1.0, 1.0]  # m1, q1, c
+        kappas1 = Float64[]        # no pairs
         out_q = zeros(2)
         out_p = zeros(2)
         q = [1.0, 2.0]
         p = [0.5, 1.0]
 
-        sys1.dq_dt_compiled(out_q, q, p, 0.0, params1)
-        sys1.dp_dt_compiled(out_p, q, p, 0.0, params1)
+        sys1.dq_dt_compiled(out_q, q, p, 0.0, params1, kappas1)
+        sys1.dp_dt_compiled(out_p, q, p, 0.0, params1, kappas1)
 
         # dq/dt = p/m (free particle)
         @test out_q[1] ≈ 0.5 / 2.0  # px/m = 0.25

--- a/test/test_named_term.jl
+++ b/test/test_named_term.jl
@@ -21,13 +21,14 @@
 
         q = [1.0, 0.2, -0.5, 0.3]
         p = [0.1, 0.2, -0.15, -0.1]
-        # params = [m1, m2, q1, q2, c, κ12]
-        params = [1.0, 2.0, 1.0, -1.0, 5.0, 1.3]
+        # params = [m1, m2, q1, q2, c]; kappas = [κ12]
+        params = [1.0, 2.0, 1.0, -1.0, 5.0]
+        kappas = [1.3]
 
         masses = params[1:2]
         charges = params[3:4]
         c_val = params[5]
-        κ = params[6]
+        κ = kappas[1]
 
         coulomb, velocity, rdot, zollner_extra =
             WeberElectrodynamics.compute_pair_weber_components(
@@ -42,8 +43,8 @@
                 κ,
             )
 
-        wr = weber.pair_decomposition(1, 2, q, p, params)
-        zr = zol.pair_decomposition(1, 2, q, p, params)
+        wr = weber.pair_decomposition(1, 2, q, p, params, kappas)
+        zr = zol.pair_decomposition(1, 2, q, p, params, kappas)
 
         @test wr.coulomb ≈ coulomb
         @test wr.velocity ≈ velocity
@@ -55,8 +56,8 @@
         @test zr.rdot ≈ rdot
 
         # κ = 1 → Zöllner contribution vanishes identically.
-        params_k1 = [1.0, 2.0, 1.0, -1.0, 5.0, 1.0]
-        zr1 = zol.pair_decomposition(1, 2, q, p, params_k1)
+        kappas_k1 = [1.0]
+        zr1 = zol.pair_decomposition(1, 2, q, p, params, kappas_k1)
         @test zr1.zollner_extra == 0.0
     end
 
@@ -67,14 +68,15 @@
 
         q = [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.5, 0.2]
         p = [0.1, 0.0, 0.0, -0.1, 0.05, 0.0, 0.0, -0.05, 0.02]
-        # params = [m1, m2, m3, q1, q2, q3, c, κ12, κ13, κ23]
-        params = [1.0, 1.0, 1.0, 1.0, -1.0, 1.0, 8.0, 1.1, 1.0, 1.2]
+        # params = [m1, m2, m3, q1, q2, q3, c]; kappas = [κ12, κ13, κ23]
+        params = [1.0, 1.0, 1.0, 1.0, -1.0, 1.0, 8.0]
+        kappas = [1.1, 1.0, 1.2]
 
         masses = params[1:3]
         charges = params[4:6]
         c_val = params[7]
 
-        for (i, j, κ) in ((1, 2, params[8]), (1, 3, params[9]), (2, 3, params[10]))
+        for (i, j, κ) in ((1, 2, kappas[1]), (1, 3, kappas[2]), (2, 3, kappas[3]))
             coulomb, velocity, rdot, zollner_extra =
                 WeberElectrodynamics.compute_pair_weber_components(
                     q,
@@ -88,8 +90,8 @@
                     κ,
                 )
 
-            wr = weber.pair_decomposition(i, j, q, p, params)
-            zr = zol.pair_decomposition(i, j, q, p, params)
+            wr = weber.pair_decomposition(i, j, q, p, params, kappas)
+            zr = zol.pair_decomposition(i, j, q, p, params, kappas)
 
             @test wr.coulomb ≈ coulomb
             @test wr.velocity ≈ velocity
@@ -121,7 +123,8 @@
         @variables m1 m2 m3 q1 q2 q3 cc k12 k13 k23 tt
         q_syms = [x1, y1, x2, y2, x3, y3]
         p_syms = [px1, py1, px2, py2, px3, py3]
-        param_syms = [m1, m2, m3, q1, q2, q3, cc, k12, k13, k23]
+        param_syms = [m1, m2, m3, q1, q2, q3, cc]
+        kappa_syms = [k12, k13, k23]
 
         H_pure = weber_term(
             q_syms,
@@ -148,6 +151,7 @@
             q_syms,
             p_syms;
             param_symbols = param_syms,
+            kappa_symbols = kappa_syms,
             t = tt,
             n_particles = 3,
             dims = 2,

--- a/test/test_physics.jl
+++ b/test/test_physics.jl
@@ -221,15 +221,16 @@
         q = [1.0, 0.0, -1.0, 0.0]
         p = [0.0, 0.5, 0.0, -0.5]
 
-        # Params layout: [m1, m2, q1, q2, c, κ₁₂]; κ=1 (Zöllner disabled)
-        params_large_c = [m1, m2, q1, q2, 1e10, 1.0]
-        params_small_c = [m1, m2, q1, q2, 10.0, 1.0]
+        # Params layout: [m1, m2, q1, q2, c]; kappas: [κ₁₂] = [1.0] (Zöllner disabled)
+        params_large_c = [m1, m2, q1, q2, 1e10]
+        params_small_c = [m1, m2, q1, q2, 10.0]
+        kappas = [1.0]
 
         out_large_c = zeros(4)
         out_small_c = zeros(4)
 
-        sys.dp_dt_compiled(out_large_c, q, p, 0.0, params_large_c)
-        sys.dp_dt_compiled(out_small_c, q, p, 0.0, params_small_c)
+        sys.dp_dt_compiled(out_large_c, q, p, 0.0, params_large_c, kappas)
+        sys.dp_dt_compiled(out_small_c, q, p, 0.0, params_small_c, kappas)
 
         # Force magnitude should be similar but with small Weber correction for finite c
         @test norm(out_large_c) ≈ norm(out_small_c) rtol = 0.1

--- a/test/test_types.jl
+++ b/test/test_types.jl
@@ -35,8 +35,9 @@
         @test !isnothing(system.dq_dt_compiled)
         @test !isnothing(system.dp_dt_compiled)
 
-        # Symbolic parameters exist: [m1, m2, q1, q2, c, kappa_1_2]
-        @test length(system.param_symbols) == 6  # m1, m2, q1, q2, c, κ₁₂
+        # Symbolic parameters exist: [m1, m2, q1, q2, c]; κ stored separately in kappa_symbols
+        @test length(system.param_symbols) == 5  # m1, m2, q1, q2, c
+        @test length(system.kappa_symbols) == 1  # κ₁₂
         @test length(system.q_symbols) == 4  # x1, y1, x2, y2
         @test length(system.p_symbols) == 4  # px1, py1, px2, py2
     end
@@ -90,9 +91,9 @@
         @test prob.dt == 0.01
         @test prob.convergence_tolerance == 1e-13  # default
         @test prob.maximum_iterations == 100  # default
-        # params = [m1, m2, q1, q2, c, κ₁₂]; charges +1/-1 are unlike so κ=1 (Zöllner disabled)
-        @test params(prob) == [1.0, 0.5, 1.0, -1.0, 4.0, 1.0]
-        @test kappas(prob) == [1.0]  # unlike charges but Zöllner disabled → κ=1
+        # params = [m1, m2, q1, q2, c]; kappas = [κ₁₂]; Zöllner disabled → κ=1
+        @test params(prob) == [1.0, 0.5, 1.0, -1.0, 4.0]
+        @test kappas(prob) == [1.0]
 
         # Custom convergence_tolerance and maximum_iterations
         prob2 = HamiltonianProblem(

--- a/test/test_zollner.jl
+++ b/test/test_zollner.jl
@@ -80,8 +80,8 @@
         @test kappas(prob)[3] ≈ 1.0 + a   # pair (2,3): unlike
     end
 
-    @testset "Params vector length" begin
-        # For N particles: params length = 2N + 1 + N*(N-1)/2
+    @testset "Params and kappas vector lengths" begin
+        # For N particles: params length = 2N + 1, kappas length = N*(N-1)/2
         for N in [2, 3, 4]
             sys = HamiltonianSystem(N, 2)
             q0 = zeros(N * 2)
@@ -98,12 +98,14 @@
                 c = 10.0,
                 dt = 0.01,
             )
-            expected_len = 2N + 1 + N * (N - 1) ÷ 2
-            @test length(params(prob)) == expected_len
+            @test length(params(prob)) == 2N + 1
             @test length(kappas(prob)) == N * (N - 1) ÷ 2
-            # params must literally end with the kappas values
-            n_pairs = N * (N - 1) ÷ 2
-            @test params(prob)[(end-n_pairs+1):end] == kappas(prob)
+            # kappas accessor aligns with the _pair_index order via kappa(prob, i, j)
+            for i = 1:N, j = (i+1):N
+                @test kappa(prob, i, j) == kappas(prob)[
+                    WeberElectrodynamics._pair_index(i, j, N)
+                ]
+            end
         end
     end
 
@@ -122,8 +124,6 @@
             zollner = ZollnerOptions(enabled = false, a = 0.5),
         )
         @test all(k -> k ≈ 1.0, kappas(prob_off))
-        # params tail should be all 1.0
-        @test params(prob_off)[end] ≈ 1.0
     end
 
     @testset "Integration runs with Zöllner enabled" begin
@@ -220,7 +220,7 @@
         # Verify that κ ≠ 1 is actually used inside regularization substeps,
         # not just during unregularized steps.  Use a circular orbit at r0 < r_on
         # so regularization fires on every step.  Energy conservation confirms
-        # the params_pair kappas path is exercised correctly.
+        # the kappas_pair path is exercised correctly.
         a = 0.05
         m1 = m2 = 1.0
         q1 = 0.1
@@ -255,7 +255,7 @@
         @test sol.retcode == :Success
         # r0 < r_on so regularization fires on every step.
         @test sol.regularization.pair_steps > 0
-        # Energy conservation validates the params_pair kappas path.
+        # Energy conservation validates the kappas_pair path.
         energy = compute_energy_timeseries(sol)
         E0 = energy.total_energy[1]
         if abs(E0) > 1e-10


### PR DESCRIPTION
## Summary
- Split per-pair Zöllner coupling κ out of the flat `params` vector into a first-class `HamiltonianProblem.kappas` field. `params` shrinks from `2N+1+N(N-1)/2` to `2N+1`.
- Compiled EOMs now take κ as a separate positional arg: `dq_dt_compiled(out, q, p, t, params, kappas)` (same for `dp_dt` and `hamiltonian_compiled`).
- New `kappa(prob, i, j)` accessor; `_pair_index` no longer appears in `solve.jl`, `statistics/`, or `ext/`.

## Breaking changes
Direct callers of compiled EOMs and any code that spliced κ onto `params` literals or sliced `params[tail]` must update. See `RELEASENOTES.md` for the migration guide.

## Test plan
- [x] `julia --project=. -e 'using Pkg; Pkg.test()'` — 20454 passed / 0 failed
- [x] Acceptance bar: `_pair_index` only appears in `hamiltonian_system.jl` (definition + `kappa` accessor) and the weber/zollner builders
- [x] Regression fixtures (`twobody_ellipse`, `threebody_mixed`, `close_approach_lifted`, `zollner_offmatch`) all agree to 1e-12

🤖 Generated with [Claude Code](https://claude.com/claude-code)