### PR TITLE
docs: pre-0.5.0 API accuracy fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ periods.
 ```julia
 using WeberElectrodynamics, Plots
 
-system = WeberSystem(2, 2)
-prob = WeberProblem(system, (0.0, 27.14),
+system = HamiltonianSystem(2, 2)
+prob = HamiltonianProblem(system, (0.0, 27.14),
     [-1.0, 0.0,  1.0, 0.0],        # q(0): particles at (±1, 0)
     [ 0.0, -0.25, 0.0, 0.25];      # p(0): |p| = 1/4 tangential
     masses = [1.0, 1.0], charges = [1.0, -1.0], c = 4.0, dt = 0.001,

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -15,8 +15,8 @@ This release completes the layered **System → Problem → Algorithm → Callba
 
 ### Added
 
-- `RegularizedIntegrator{BaseAlg}` algorithm wrapper preserving symplectic projection via the base algorithm's `projection_kernel`.
-- `CollisionBounce(radius)` pre-step callback. `CallbackSet(...)` composition.
+- `RegularizedIntegrator{BaseAlg}` algorithm wrapper that delegates the inner step to the wrapped base algorithm via `_step_core!` / `_allocate_cache` hooks, preserving its symplectic projection while interleaving Levi-Civita / KS substeps near close encounters.
+- `CollisionBounce(radius)` pre-step callback. Compose callbacks by passing a tuple (or any iterable of `HamiltonianCallback`) to the `callbacks=` kwarg of `solve` / `init`.
 - Accessor API on `HamiltonianSystem` and `HamiltonianProblem` to insulate downstream code from struct layout.
 - `NamedTerm{S}` with per-term compiled EOMs and optional `pair_decomposition(i, j, q, p, params, kappas)` for pair-wise statistics.
 - `kappa(prob, i, j)` per-pair accessor, co-located with `_pair_index` in `hamiltonian_system.jl`.

--- a/docs/src/api/problem.md
+++ b/docs/src/api/problem.md
@@ -8,19 +8,26 @@ HamiltonianProblem
 
 ## Accessors
 
-Read-only accessors on a `HamiltonianProblem`. `masses`, `charges`, and
-`kappas` return views into the backing `params` vector (layout
-`[m₁…mₙ, q₁…qₙ, c, κ…]`), so they are O(1) and allocation-free.
+Read-only accessors on a `HamiltonianProblem`. The backing `params` vector
+has layout `[m₁…mₙ, q₁…qₙ, c]` (length `2N + 1`). `masses(prob)` and
+`charges(prob)` are O(1) views into `params(prob)`; `speed_of_light(prob)`
+reads the trailing `c` element. The per-pair Zöllner coupling `kappas`
+lives on its own field of length `N(N−1)/2`, separate from `params`.
 
 | Function | Returns |
 |----------|---------|
-| `masses(prob)` | `AbstractVector{Float64}` of particle masses |
-| `charges(prob)` | `AbstractVector{Float64}` of particle charges |
+| `masses(prob)` | `AbstractVector{Float64}` view of particle masses (length `N`) |
+| `charges(prob)` | `AbstractVector{Float64}` view of particle charges (length `N`) |
 | `speed_of_light(prob)` | `Float64` — the `c` passed at construction |
-| `kappas(prob)` | `AbstractVector{Float64}` — per-pair Zöllner κ values (all `1.0` when Zöllner is disabled) |
+| `kappas(prob)` | `Vector{Float64}` of per-pair Zöllner κ values (all `1.0` when Zöllner is disabled; `Float64[]` for `N = 1`) |
+| `kappa(prob, i, j)` | `Float64` — coupling for pair `(i, j)` with `i < j` |
 | `params(prob)` | the full packed `Vector{Float64}` consumed by the compiled EOMs |
 
 See also `n_particles(prob)` and `dims(prob)`, documented on the [System](system.md) page.
+
+```@docs
+kappa
+```
 
 ## Optional features
 

--- a/docs/src/api/system.md
+++ b/docs/src/api/system.md
@@ -7,13 +7,33 @@ across many `HamiltonianProblem` instances.
 ```@docs
 HamiltonianSystem
 HamiltonianSystem(::Int, ::Int)
+HamiltonianSystem(::Any, ::AbstractVector, ::AbstractVector)
+```
+
+The generic constructor takes a pre-built symbolic Hamiltonian `H` and the
+phase-space variables, then derives Hamilton's equations and compiles them.
+Use it to assemble a custom Hamiltonian from term builders, e.g.
+
+```julia
+H = kinetic_term(p_vars; masses = m_vars, n_particles, dims) +
+    coulomb_term(q_vars; charges = q_charges, n_particles, dims)
+
+sys = HamiltonianSystem(H, q_vars, p_vars;
+    param_symbols = vcat(m_vars, q_charges, [c_var]),
+    kappa_symbols = Num[],   # no κ dependence
+    t = t_var, n_particles = n_particles, dims = dims,
+)
 ```
 
 ## Term builders
 
+Composable building blocks for symbolic Hamiltonians.
+
 ```@docs
 weber_term
 zollner_term
+kinetic_term
+coulomb_term
 ```
 
 ## Term introspection
@@ -24,6 +44,14 @@ term_names
 has_term
 get_term
 ```
+
+A `NamedTerm` may attach an optional `pair_decomposition(i, j, q, p, params, kappas)`
+closure that returns a `NamedTuple` summarising the term's contribution to a
+single pair — used by the energy/force statistics to avoid re-deriving
+per-term decompositions. The default `:weber` and `:zollner` terms supply
+their own closures; custom terms may attach any `NamedTuple` shape, but
+the built-in statistics consume specific field names (`coulomb`, `velocity`,
+`rdot`, `r`, `zollner_extra`).
 
 ## Metadata accessors
 


### PR DESCRIPTION
## Summary

Pre-v0.5.0 audit surfaced four stale doc/release-notes claims that misrepresent the API actually shipped by the layered refactor. Pure docs change, no source code or tests touched.

- **README.md** — quick-start used `WeberSystem`/`WeberProblem` (renamed to `HamiltonianSystem`/`HamiltonianProblem` in PR #41).
- **RELEASENOTES.md** — `CallbackSet(...)` composition is advertised, but no `CallbackSet` symbol exists or is exported; callbacks compose via tuples passed to `solve(...; callbacks=...)`. Same line falsely credits a `projection_kernel` (no such symbol) — replaced with the actual `_step_core!` / `_allocate_cache` hook design used by `RegularizedIntegrator`.
- **docs/src/api/problem.md** — text claimed `kappas` is a view into `params` with layout `[m₁…mₙ, q₁…qₙ, c, κ…]`. After the kappa-storage refactor (PR #76), `params` is `[m…, q…, c]` and `kappas` is its own `HamiltonianProblem` field. Fixed the prose and added a row for `kappa(prob, i, j)`.
- **docs/src/api/system.md** — added `@docs` entries for the generic `HamiltonianSystem(H, q, p; …)` ctor, `kinetic_term`, `coulomb_term`, plus a short prose example of attaching a `pair_decomposition` closure to a `NamedTerm`. The `kappa` docstring previously triggered a "not included in the manual" Documenter warning — that's now resolved.

## Test plan

- [x] `julia --project=docs/ docs/make.jl` builds clean (no missing-docstring warnings, all `@docs` blocks resolve).
- [x] No source code touched — existing test suite still applies.
- [ ] CI green on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)