### PR TITLE
fix: assert i<j in kappa(prob, i, j) accessor

### DIFF
--- a/src/hamiltonian_system.jl
+++ b/src/hamiltonian_system.jl
@@ -85,7 +85,14 @@ function _generate_param_symbols(n_particles::Int)
 end
 
 # Pair (i,j) with i<j maps to this 1-based index in the kappas vector.
+# Only called at HamiltonianSystem construction time (symbolic builders) and
+# from the public kappa(prob, i, j) accessor — never from the integrator hot
+# loop, so the bounds guard is essentially free. The guard elides under
+# `@inbounds` for the symbolic builder callers that already wrap their access.
 @inline function _pair_index(i::Int, j::Int, n::Int)::Int
+    Base.@boundscheck (1 <= i < j <= n) || throw(
+        ArgumentError("_pair_index requires 1 ≤ i < j ≤ n; got i=$i, j=$j, n=$n"),
+    )
     return (i - 1) * (2n - i) ÷ 2 + (j - i)
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -580,10 +580,15 @@ params(prob::HamiltonianProblem) = prob.params
 """
     kappa(prob::HamiltonianProblem, i::Int, j::Int) -> Float64
 
-Return the Zöllner coupling `κ_ij` for pair `(i, j)` with `i < j`.
+Return the Zöllner coupling `κ_ij` for pair `(i, j)`. Indices must satisfy
+`1 ≤ i < j ≤ n_particles(prob)`; the function asserts the ordering rather
+than silently returning the wrong pair-index value.
 """
-kappa(prob::HamiltonianProblem, i::Int, j::Int) =
-    prob.kappas[_pair_index(i, j, n_particles(prob))]
+function kappa(prob::HamiltonianProblem, i::Int, j::Int)
+    n = n_particles(prob)
+    @assert 1 <= i < j <= n "kappa requires 1 ≤ i < j ≤ $n, got i=$i, j=$j"
+    return prob.kappas[_pair_index(i, j, n)]
+end
 
 # Internal: clone a problem with an overridden tspan while preserving the
 # compiled system, initial conditions, packed params, and κ vector. Used by

--- a/test/test_accessors.jl
+++ b/test/test_accessors.jl
@@ -56,4 +56,47 @@
         @test κ ≈ [1.1, 1.0, 1.1]
     end
 
+    @testset "kappa argument validation" begin
+        prob = HamiltonianProblem(
+            sys,
+            (0.0, 1.0),
+            zeros(6),
+            zeros(6);
+            masses = [1.0, 2.0, 3.0],
+            charges = [1.0, -1.0, 0.5],
+            c = 10.0,
+            dt = 0.01,
+        )
+        # Valid index ordering — no throw.
+        @test kappa(prob, 1, 2) == 1.0
+        @test kappa(prob, 2, 3) == 1.0
+        # Reversed (i ≥ j) must throw rather than silently return wrong κ.
+        @test_throws AssertionError kappa(prob, 2, 1)
+        @test_throws AssertionError kappa(prob, 3, 2)
+        @test_throws AssertionError kappa(prob, 1, 1)
+        # Out-of-range indices.
+        @test_throws AssertionError kappa(prob, 0, 1)
+        @test_throws AssertionError kappa(prob, 1, 4)
+    end
+
+    @testset "accessor view aliasing" begin
+        prob = HamiltonianProblem(
+            sys,
+            (0.0, 1.0),
+            zeros(6),
+            zeros(6);
+            masses = [1.0, 2.0, 3.0],
+            charges = [1.0, -1.0, 0.5],
+            c = 10.0,
+            dt = 0.01,
+        )
+        # masses(prob) and charges(prob) are O(1) views into prob.params —
+        # parent identity proves they share memory rather than copy.
+        @test parent(masses(prob)) === params(prob)
+        @test parent(charges(prob)) === params(prob)
+        # kappas lives on its own field, NOT a slice of params.
+        @test kappas(prob) === prob.kappas
+        @test parent(kappas(prob)) !== params(prob)
+    end
+
 end


### PR DESCRIPTION
## Summary

Pre-v0.5.0 audit caught a silent-wrong-result risk in the public per-pair Zöllner accessor.

- `kappa(prob, i, j)` previously delegated to `_pair_index` without validating ordering. Calling `kappa(prob, 2, 1)` would return `_pair_index(2, 1, n)` — a different but in-range κ, with no error. The docstring already required `i < j` but never enforced it.
- `_pair_index` gains a `Base.@boundscheck` guard. It is only ever called at `HamiltonianSystem` construction time (inside the symbolic builders) and from the public `kappa` accessor — never from the integrator hot loop — so the check is free in practice.

## Tests added

In [test/test_accessors.jl](test/test_accessors.jl):

- `@testset "kappa argument validation"` — exercises `kappa(prob, 2, 1)`, `(3, 2)`, `(1, 1)`, `(0, 1)`, `(1, 4)` and asserts each throws `AssertionError`. Confirms valid `(1, 2)` and `(2, 3)` still return.
- `@testset "accessor view aliasing"` — asserts `parent(masses(prob)) === params(prob)` and same for `charges`, locking in the O(1)-view contract documented in `docs/src/api/problem.md`. `kappas(prob)` is the standalone field (`parent(kappas(prob)) !== params(prob)`), matching the post-PR-#76 storage layout.

## Test plan

- [x] `julia --project=. -e 'using Pkg; Pkg.test()'` — full suite green (20,465 / 20,465 pass) including the four regression fixtures at 1e-12.
- [x] No formatter drift on touched files.
- [ ] CI green on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)