### PR TITLE
docs: add api_showcase notebook covering v0.5.0 API surface

### DIFF
--- a/examples/api_showcase.ipynb
+++ b/examples/api_showcase.ipynb
@@ -1,0 +1,383 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# WeberElectrodynamics.jl — v0.5.0 API showcase\n",
+    "\n",
+    "This notebook lives alongside [`two_body_reference.ipynb`](two_body_reference.ipynb) and exercises the post-refactor (v0.5.0) API surfaces that the reference notebook does not touch:\n",
+    "\n",
+    "1. **Custom Hamiltonian** built from `kinetic_term + coulomb_term` via the generic `HamiltonianSystem(H, q, p; …)` constructor (no Weber velocity term).\n",
+    "2. **Term introspection** — `term_names`, `has_term`, `get_term`, and the per-term `pair_decomposition` closure.\n",
+    "3. **Accessor tour** — `masses`, `charges`, `speed_of_light`, `kappas`, `kappa(prob, i, j)`, `params`, plus the shape accessors. Includes proof that `masses(prob)` is an O(1) view into `params(prob)`.\n",
+    "4. **N = 3 with mixed charges and a neutral particle** under Zöllner — verifies the documented `sign(0.0) == 0.0` semantics.\n",
+    "5. **3D regularization** with the `:adaptive_cartesian` backend (the only one supported in 3D).\n",
+    "6. **`CollisionBounce` callback** on its own — sub-critical like-charge oscillation in 2D.\n",
+    "7. **Combined regularization + bounce** — `RegularizedIntegrator` synthesises a `CollisionBounce` from the `collision_bounce_radius` kwarg, matching an explicit one bit-for-bit.\n",
+    "\n",
+    "A plain-Julia mirror of every cell lives in [`api_showcase.jl`](api_showcase.jl) for headless runs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "using WeberElectrodynamics\n",
+    "using LinearAlgebra: norm\n",
+    "using Symbolics: @variables, Num\n",
+    "using Printf: @printf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1 — Custom Hamiltonian: pure Coulomb (no Weber velocity term)\n",
+    "\n",
+    "The generic `HamiltonianSystem(H, q_vars, p_vars; …)` constructor takes a pre-built symbolic Hamiltonian and compiles its equations of motion. We assemble `H = kinetic_term + coulomb_term` to integrate a 2-body Kepler orbit without the Weber velocity correction or any Zöllner coupling."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@variables x1 y1 x2 y2 px1 py1 px2 py2 m1 m2 qq1 qq2 cc tt\n",
+    "q_syms = [x1, y1, x2, y2]\n",
+    "p_syms = [px1, py1, px2, py2]\n",
+    "\n",
+    "H_pure_coulomb =\n",
+    "    kinetic_term(p_syms; masses = [m1, m2], n_particles = 2, dims = 2) +\n",
+    "    coulomb_term(q_syms; charges = [qq1, qq2], n_particles = 2, dims = 2)\n",
+    "\n",
+    "sys_coulomb = HamiltonianSystem(\n",
+    "    H_pure_coulomb,\n",
+    "    q_syms,\n",
+    "    p_syms;\n",
+    "    param_symbols = [m1, m2, qq1, qq2, cc],   # `cc` unused but the params layout requires it\n",
+    "    kappa_symbols = Num[],\n",
+    "    t = tt,\n",
+    "    n_particles = 2,\n",
+    "    dims = 2,\n",
+    ")\n",
+    "sys_coulomb.hamiltonian_symbolic"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Bound elliptic orbit: m1=m2=1, q1q2=-1 (attractive). Sub-circular tangential\n",
+    "# velocity gives a mild ellipticity. Period derived analytically.\n",
+    "m1_v, m2_v = 1.0, 1.0\n",
+    "q1_v, q2_v = 1.0, -1.0\n",
+    "r0 = 2.0\n",
+    "M = m1_v + m2_v\n",
+    "μ_red = m1_v * m2_v / M\n",
+    "v_circ = sqrt(abs(q1_v * q2_v) / (μ_red * r0))\n",
+    "v_init = 0.95 * v_circ\n",
+    "q0 = [-m2_v / M * r0, 0.0, m1_v / M * r0, 0.0]\n",
+    "p0 = [0.0, m1_v * (-m2_v / M * v_init), 0.0, m2_v * (m1_v / M * v_init)]\n",
+    "E_keplerian =\n",
+    "    0.5 * (sum(p0[1:2] .^ 2) / m1_v + sum(p0[3:4] .^ 2) / m2_v) + q1_v * q2_v / r0\n",
+    "k_kepler = -q1_v * q2_v\n",
+    "a_kepler = k_kepler / (-2 * E_keplerian)\n",
+    "T_kepler = 2π * sqrt(μ_red * a_kepler^3 / k_kepler)\n",
+    "\n",
+    "prob_coulomb = HamiltonianProblem(\n",
+    "    sys_coulomb,\n",
+    "    (0.0, T_kepler),\n",
+    "    q0,\n",
+    "    p0;\n",
+    "    masses = [m1_v, m2_v],\n",
+    "    charges = [q1_v, q2_v],\n",
+    "    c = 1.0,\n",
+    "    dt = T_kepler / 10_000,\n",
+    ")\n",
+    "sol_coulomb = solve(prob_coulomb)\n",
+    "@printf \"retcode=%s  steps=%d  closing offset Δq=%.2e\\n\" sol_coulomb.retcode length(\n",
+    "    sol_coulomb.t,\n",
+    ") maximum(abs, sol_coulomb.q[end] .- q0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2 — Term introspection\n",
+    "\n",
+    "The default `HamiltonianSystem(n, dims)` decomposes its Hamiltonian into named `:weber` and `:zollner` terms. Each term carries a `pair_decomposition(i, j, q, p, params, kappas)` closure used by the energy and force statistics — a custom term may attach any compatible closure."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sys_default = HamiltonianSystem(2, 2)\n",
+    "@printf \"term_names(sys) = %s\\n\" term_names(sys_default)\n",
+    "@printf \"has_term(:weber)   = %s\\n\" has_term(sys_default, :weber)\n",
+    "@printf \"has_term(:zollner) = %s\\n\" has_term(sys_default, :zollner)\n",
+    "\n",
+    "prob_default = HamiltonianProblem(\n",
+    "    sys_default,\n",
+    "    (0.0, 0.5),\n",
+    "    [1.0, 0.0, -1.0, 0.0],\n",
+    "    [0.0, 0.2, 0.0, -0.2];\n",
+    "    masses = [1.0, 1.0],\n",
+    "    charges = [1.0, -1.0],\n",
+    "    c = 5.0,\n",
+    "    dt = 0.005,\n",
+    "    zollner = ZollnerOptions(enabled = true, a = 0.05),\n",
+    ")\n",
+    "weber = get_term(sys_default, :weber)\n",
+    "decomp = weber.pair_decomposition(\n",
+    "    1,\n",
+    "    2,\n",
+    "    prob_default.q_initial,\n",
+    "    prob_default.p_initial,\n",
+    "    params(prob_default),\n",
+    "    kappas(prob_default),\n",
+    ")\n",
+    "@printf \"Weber pair (1,2) at IC:  coulomb=%.4e  velocity=%.4e  r=%.3f  rdot=%.3e\\n\" decomp.coulomb decomp.velocity decomp.r decomp.rdot"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3 — Accessor tour\n",
+    "\n",
+    "Every public accessor on a `HamiltonianProblem`. The proof at the bottom shows `masses(prob)` aliases `params(prob)` (it is an O(1) view, not a copy)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@printf \"n_particles(prob) = %d\\n\" n_particles(prob_default)\n",
+    "@printf \"dims(prob)        = %d\\n\" dims(prob_default)\n",
+    "@printf \"masses(prob)      = %s\\n\" string(collect(masses(prob_default)))\n",
+    "@printf \"charges(prob)     = %s\\n\" string(collect(charges(prob_default)))\n",
+    "@printf \"speed_of_light    = %g\\n\" speed_of_light(prob_default)\n",
+    "@printf \"kappas(prob)      = %s\\n\" string(kappas(prob_default))\n",
+    "@printf \"kappa(prob, 1, 2) = %g\\n\" kappa(prob_default, 1, 2)\n",
+    "@printf \"params(prob)      = %s\\n\" string(params(prob_default))\n",
+    "@printf \"\\nparent(masses(prob)) === params(prob)  → %s   (O(1) view, not a copy)\\n\" (\n",
+    "    parent(masses(prob_default)) === params(prob_default)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4 — N = 3 with a neutral particle under Zöllner\n",
+    "\n",
+    "Charges `[+1, 0, -1]` with `ZollnerOptions(enabled = true, a = 0.07)`. Per the implementation comment in [`src/types.jl`](../src/types.jl) (`sign(0.0) == 0.0` ⇒ a neutral particle is treated as unlike any charged neighbour), every pair receives κ = 1 + a. `kappa(prob, i, j)` is the per-pair accessor."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sys_n3 = HamiltonianSystem(3, 2)\n",
+    "prob_n3 = HamiltonianProblem(\n",
+    "    sys_n3,\n",
+    "    (0.0, 0.4),\n",
+    "    [1.0, 0.0, 0.0, 0.0, -1.0, 0.0],\n",
+    "    zeros(6);\n",
+    "    masses = [1.0, 1.0, 1.0],\n",
+    "    charges = [1.0, 0.0, -1.0],\n",
+    "    c = 5.0,\n",
+    "    dt = 0.002,\n",
+    "    zollner = ZollnerOptions(enabled = true, a = 0.07),\n",
+    ")\n",
+    "@printf \"kappas(prob) = %s\\n\" string(kappas(prob_n3))\n",
+    "for (i, j) in ((1, 2), (1, 3), (2, 3))\n",
+    "    @printf \"  kappa(prob, %d, %d) = %g\\n\" i j kappa(prob_n3, i, j)\n",
+    "end\n",
+    "sol_n3 = solve(prob_n3)\n",
+    "@printf \"retcode=%s  steps=%d\\n\" sol_n3.retcode length(sol_n3.t)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5 — 3D regularization with `:adaptive_cartesian`\n",
+    "\n",
+    "The `:lifted_pair` Levi-Civita backend is 2D-only and auto-falls back to `:adaptive_cartesian` for 3D (with a warning unless `warn_on_fallback = false`). `:adaptive_cartesian` is the only 3D-supported backend; this cell exercises it on a 2-body close approach.\n",
+    "\n",
+    "The regularization diagnostics on the returned solution count activations, substeps, and the closest encounter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sys_3d = HamiltonianSystem(2, 3)\n",
+    "m1_3d, m2_3d = 1.0, 0.1\n",
+    "q1_3d, q2_3d = sqrt(0.1), -sqrt(0.1)\n",
+    "c_3d = 4.0\n",
+    "r0_3d = 2.0\n",
+    "M_3d = m1_3d + m2_3d\n",
+    "v_circ_3d = sqrt(abs(q1_3d * q2_3d) * M_3d / (m1_3d * m2_3d * r0_3d))\n",
+    "v_3d = 0.5 * v_circ_3d\n",
+    "q0_3d = [-m2_3d / M_3d * r0_3d, 0.0, 0.0, m1_3d / M_3d * r0_3d, 0.0, 0.0]\n",
+    "p0_3d = [\n",
+    "    0.0,\n",
+    "    m1_3d * (-m2_3d / M_3d * v_3d),\n",
+    "    0.0,\n",
+    "    0.0,\n",
+    "    m2_3d * (m1_3d / M_3d * v_3d),\n",
+    "    0.0,\n",
+    "]\n",
+    "prob_3d = HamiltonianProblem(\n",
+    "    sys_3d,\n",
+    "    (0.0, 8.0),\n",
+    "    q0_3d,\n",
+    "    p0_3d;\n",
+    "    masses = [m1_3d, m2_3d],\n",
+    "    charges = [q1_3d, q2_3d],\n",
+    "    c = c_3d,\n",
+    "    dt = 2e-3,\n",
+    ")\n",
+    "alg_3d = RegularizedIntegrator(\n",
+    "    SymmetricProjectionIntegrator();\n",
+    "    backend = :adaptive_cartesian,\n",
+    "    r_on_factor = 0.3,\n",
+    "    r_off_factor = 0.45,\n",
+    "    warn_on_fallback = false,\n",
+    ")\n",
+    "sol_3d = solve(prob_3d, alg_3d)\n",
+    "diag = sol_3d.regularization\n",
+    "@printf \"retcode=%s  steps=%d\\n\" sol_3d.retcode length(sol_3d.t)\n",
+    "@printf \"used_backend       = %s\\n\" diag.used_backend\n",
+    "@printf \"activation_count   = %d\\n\" diag.activation_count\n",
+    "@printf \"active_steps       = %d\\n\" diag.active_steps\n",
+    "@printf \"total_substeps     = %d\\n\" diag.total_substeps\n",
+    "@printf \"min encounter dist = %.3e\\n\" diag.min_encounter_distance"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6 — `CollisionBounce` callback on a sub-critical like-charge oscillation\n",
+    "\n",
+    "Frauenfelder–Weber sub-critical regime: like-sign charges fall in through near-zero separation (Weber's velocity term overcomes Coulomb repulsion). The `CollisionBounce(r)` pre-step callback reflects the relative coordinate when the pair separation drops below `r`, providing a $C^0$ continuation of the head-on (ℓ = 0) collision (Frauenfelder & Weber 2024).\n",
+    "\n",
+    "The validated parameters (see `_research/Investigations/CollisionBounceRegularization.md`) use absolute `dt = 1e-4` (not period-scaled) with `bounce_r = 0.02`, giving ~0.01 % global energy drift over 100 periods. We run 3 periods here."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m_b = 1.0\n",
+    "q_b = 1.0       # like charges\n",
+    "c_b = 4.0\n",
+    "r0_b = 0.05\n",
+    "mu_b = m_b * m_b / (m_b + m_b)\n",
+    "rho_b = q_b * q_b / (mu_b * c_b^2)\n",
+    "T_b = (2π / c_b) * rho_b\n",
+    "sys_b = HamiltonianSystem(2, 2)\n",
+    "prob_b = HamiltonianProblem(\n",
+    "    sys_b,\n",
+    "    (0.0, 3 * T_b),\n",
+    "    [r0_b / 2, 0.0, -r0_b / 2, 0.0],\n",
+    "    zeros(4);\n",
+    "    masses = [m_b, m_b],\n",
+    "    charges = [q_b, q_b],\n",
+    "    c = c_b,\n",
+    "    dt = 1e-4,\n",
+    ")\n",
+    "sol_b = solve(prob_b, SymmetricProjectionIntegrator(); callbacks = CollisionBounce(0.02))\n",
+    "en_b = compute_energy_timeseries(sol_b)\n",
+    "@printf \"retcode=%s  steps=%d\\n\" sol_b.retcode length(sol_b.t)\n",
+    "@printf \"max global energy drift = %.3e %%\\n\" abs(en_b.statistics.global_error_percent_max)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7 — `collision_bounce_radius` synthesises a CollisionBounce automatically\n",
+    "\n",
+    "When a `RegularizedIntegrator` is constructed with `collision_bounce_radius > 0`, it synthesises an equivalent `CollisionBounce` callback at `init` time — unless the user already passed one via `callbacks=…`. The trajectories are bit-identical."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "alg_synth = RegularizedIntegrator(\n",
+    "    SymmetricProjectionIntegrator();\n",
+    "    backend = :adaptive_cartesian,\n",
+    "    r_on = 0.001,\n",
+    "    r_off = 0.002,\n",
+    "    warn_on_fallback = false,\n",
+    "    collision_bounce_radius = 0.02,\n",
+    ")\n",
+    "integrator = init(prob_b, alg_synth)\n",
+    "@printf \"integrator.callbacks length            = %d\\n\" length(integrator.callbacks)\n",
+    "@printf \"integrator.callbacks[1] isa CollisionBounce = %s\\n\" (\n",
+    "    integrator.callbacks[1] isa CollisionBounce\n",
+    ")\n",
+    "@printf \"integrator.callbacks[1].radius        = %g\\n\" integrator.callbacks[1].radius\n",
+    "\n",
+    "alg_explicit = RegularizedIntegrator(\n",
+    "    SymmetricProjectionIntegrator();\n",
+    "    backend = :adaptive_cartesian,\n",
+    "    r_on = 0.001,\n",
+    "    r_off = 0.002,\n",
+    "    warn_on_fallback = false,\n",
+    ")\n",
+    "sol_synth = solve(prob_b, alg_synth)\n",
+    "sol_explicit = solve(prob_b, alg_explicit; callbacks = CollisionBounce(0.02))\n",
+    "max_dq = maximum(\n",
+    "    maximum(abs, sol_synth.q[i] .- sol_explicit.q[i]) for i in eachindex(sol_synth.q)\n",
+    ")\n",
+    "max_dp = maximum(\n",
+    "    maximum(abs, sol_synth.p[i] .- sol_explicit.p[i]) for i in eachindex(sol_synth.p)\n",
+    ")\n",
+    "@printf \"\\nbit-exact match against explicit CollisionBounce:\\n\"\n",
+    "@printf \"  max|Δq| = %.2e\\n\" max_dq\n",
+    "@printf \"  max|Δp| = %.2e\\n\" max_dp"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Julia 1.12.6",
+   "language": "julia",
+   "name": "julia-1.12"
+  },
+  "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
+   "name": "julia",
+   "version": "1.12.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/api_showcase.jl
+++ b/examples/api_showcase.jl
@@ -1,0 +1,265 @@
+#!/usr/bin/env julia
+# api_showcase.jl
+#
+# Plain-script mirror of `examples/api_showcase.ipynb` — kept in sync so the
+# notebook can be regenerated and the same code can be run headlessly. The
+# notebook lives alongside `examples/two_body_reference.ipynb` and exercises
+# the v0.5.0 API surfaces that the reference notebook does not touch:
+#
+#   1. Custom Hamiltonian via `kinetic_term + coulomb_term`
+#   2. Term introspection (`term_names`, `has_term`, `pair_decomposition`)
+#   3. Accessor tour
+#   4. N=3 mixed signs with a neutral particle (Zöllner)
+#   5. 3D regularization with `:adaptive_cartesian`
+#   6. CollisionBounce callback
+#   7. Combined RegularizedIntegrator + CollisionBounce
+#
+# Run from the project root:
+#   julia --project=. examples/api_showcase.jl
+
+using WeberElectrodynamics
+using LinearAlgebra: norm
+using Symbolics: @variables, Num
+using Printf: @printf
+
+println("=" ^ 72)
+println("WeberElectrodynamics.jl v0.5.0 API showcase")
+println("=" ^ 72)
+
+# ---------------------------------------------------------------------------
+# Section 1 — Custom Hamiltonian via term builders
+# ---------------------------------------------------------------------------
+println("\n[1] Custom Hamiltonian — kinetic_term + coulomb_term (pure Coulomb)")
+
+@variables x1 y1 x2 y2 px1 py1 px2 py2 m1 m2 qq1 qq2 cc tt
+q_syms = [x1, y1, x2, y2]
+p_syms = [px1, py1, px2, py2]
+
+H_pure_coulomb =
+    kinetic_term(p_syms; masses = [m1, m2], n_particles = 2, dims = 2) +
+    coulomb_term(q_syms; charges = [qq1, qq2], n_particles = 2, dims = 2)
+
+sys_coulomb = HamiltonianSystem(
+    H_pure_coulomb,
+    q_syms,
+    p_syms;
+    param_symbols = [m1, m2, qq1, qq2, cc],
+    kappa_symbols = Num[],
+    t = tt,
+    n_particles = 2,
+    dims = 2,
+)
+
+@printf "  H = %s\n" string(sys_coulomb.hamiltonian_symbolic)
+
+# Bound elliptic orbit with Kepler ICs.
+m1_v, m2_v = 1.0, 1.0
+q1_v, q2_v = 1.0, -1.0
+r0 = 2.0
+M = m1_v + m2_v
+μ_red = m1_v * m2_v / M
+v_circ = sqrt(abs(q1_v * q2_v) / (μ_red * r0))
+v_init = 0.95 * v_circ
+q0 = [-m2_v / M * r0, 0.0, m1_v / M * r0, 0.0]
+p0 = [0.0, m1_v * (-m2_v / M * v_init), 0.0, m2_v * (m1_v / M * v_init)]
+E_keplerian = 0.5 * (sum(p0[1:2] .^ 2) / m1_v + sum(p0[3:4] .^ 2) / m2_v) + q1_v * q2_v / r0
+T_kepler = 2π * sqrt(μ_red * (-q1_v * q2_v / (-2 * E_keplerian))^3 / (-q1_v * q2_v))
+
+prob_coulomb = HamiltonianProblem(
+    sys_coulomb,
+    (0.0, T_kepler),
+    q0,
+    p0;
+    masses = [m1_v, m2_v],
+    charges = [q1_v, q2_v],
+    c = 1.0,                     # unused by pure Coulomb but required by the params layout
+    dt = T_kepler / 10_000,
+)
+sol_coulomb = solve(prob_coulomb)
+@printf "  retcode=%s  steps=%d  Δq(end-start)=%.2e\n" sol_coulomb.retcode length(
+    sol_coulomb.t,
+) maximum(abs, sol_coulomb.q[end] .- q0)
+
+# ---------------------------------------------------------------------------
+# Section 2 — Term introspection
+# ---------------------------------------------------------------------------
+println("\n[2] Term introspection — default Weber+Zöllner system")
+
+sys_default = HamiltonianSystem(2, 2)
+@printf "  term_names(sys) = %s\n" term_names(sys_default)
+@printf "  has_term(sys, :weber) = %s\n" has_term(sys_default, :weber)
+@printf "  has_term(sys, :zollner) = %s\n" has_term(sys_default, :zollner)
+
+prob_default = HamiltonianProblem(
+    sys_default,
+    (0.0, 0.5),
+    [1.0, 0.0, -1.0, 0.0],
+    [0.0, 0.2, 0.0, -0.2];
+    masses = [1.0, 1.0],
+    charges = [1.0, -1.0],
+    c = 5.0,
+    dt = 0.005,
+    zollner = ZollnerOptions(enabled = true, a = 0.05),
+)
+weber = get_term(sys_default, :weber)
+decomp = weber.pair_decomposition(
+    1,
+    2,
+    prob_default.q_initial,
+    prob_default.p_initial,
+    params(prob_default),
+    kappas(prob_default),
+)
+@printf "  Weber pair decomposition (1,2): coulomb=%.4e velocity=%.4e r=%.3f rdot=%.3e\n" decomp.coulomb decomp.velocity decomp.r decomp.rdot
+
+# ---------------------------------------------------------------------------
+# Section 3 — Accessor tour
+# ---------------------------------------------------------------------------
+println("\n[3] Accessor tour")
+@printf "  n_particles(prob) = %d\n" n_particles(prob_default)
+@printf "  dims(prob) = %d\n" dims(prob_default)
+@printf "  masses(prob) = %s\n" string(collect(masses(prob_default)))
+@printf "  charges(prob) = %s\n" string(collect(charges(prob_default)))
+@printf "  speed_of_light(prob) = %g\n" speed_of_light(prob_default)
+@printf "  kappas(prob) = %s\n" string(kappas(prob_default))
+@printf "  kappa(prob, 1, 2) = %g\n" kappa(prob_default, 1, 2)
+@printf "  parent(masses(prob)) === params(prob): %s\n" (
+    parent(masses(prob_default)) === params(prob_default)
+)
+
+# ---------------------------------------------------------------------------
+# Section 4 — N=3 mixed signs with a neutral particle
+# ---------------------------------------------------------------------------
+println("\n[4] N=3 with charges [+1, 0, -1] and Zöllner enabled")
+sys_n3 = HamiltonianSystem(3, 2)
+prob_n3 = HamiltonianProblem(
+    sys_n3,
+    (0.0, 0.4),
+    [1.0, 0.0, 0.0, 0.0, -1.0, 0.0],
+    zeros(6);
+    masses = [1.0, 1.0, 1.0],
+    charges = [1.0, 0.0, -1.0],
+    c = 5.0,
+    dt = 0.002,
+    zollner = ZollnerOptions(enabled = true, a = 0.07),
+)
+@printf "  kappas(prob) = %s   (sign(0.0) == 0.0 ⇒ neutral pairs are 'unlike-sign')\n" string(
+    kappas(prob_n3),
+)
+sol_n3 = solve(prob_n3)
+@printf "  retcode=%s  steps=%d\n" sol_n3.retcode length(sol_n3.t)
+
+# ---------------------------------------------------------------------------
+# Section 5 — 3D regularization with :adaptive_cartesian
+# ---------------------------------------------------------------------------
+println("\n[5] 3D close approach with :adaptive_cartesian regularization")
+sys_3d = HamiltonianSystem(2, 3)
+m1_3d, m2_3d = 1.0, 0.1
+q1_3d, q2_3d = sqrt(0.1), -sqrt(0.1)
+c_3d = 4.0
+r0_3d = 2.0
+M_3d = m1_3d + m2_3d
+v_circ_3d = sqrt(abs(q1_3d * q2_3d) * M_3d / (m1_3d * m2_3d * r0_3d))
+v_3d = 0.5 * v_circ_3d
+q0_3d = [-m2_3d / M_3d * r0_3d, 0.0, 0.0, m1_3d / M_3d * r0_3d, 0.0, 0.0]
+p0_3d = [0.0, m1_3d * (-m2_3d / M_3d * v_3d), 0.0, 0.0, m2_3d * (m1_3d / M_3d * v_3d), 0.0]
+prob_3d = HamiltonianProblem(
+    sys_3d,
+    (0.0, 8.0),
+    q0_3d,
+    p0_3d;
+    masses = [m1_3d, m2_3d],
+    charges = [q1_3d, q2_3d],
+    c = c_3d,
+    dt = 2e-3,
+)
+alg_3d = RegularizedIntegrator(
+    SymmetricProjectionIntegrator();
+    backend = :adaptive_cartesian,
+    r_on_factor = 0.3,
+    r_off_factor = 0.45,
+    warn_on_fallback = false,
+)
+sol_3d = solve(prob_3d, alg_3d)
+diag = sol_3d.regularization
+@printf "  retcode=%s  steps=%d\n" sol_3d.retcode length(sol_3d.t)
+@printf "  regularization: backend=%s activations=%d active_steps=%d total_substeps=%d min_r=%.3e\n" diag.used_backend diag.activation_count diag.active_steps diag.total_substeps diag.min_encounter_distance
+
+# ---------------------------------------------------------------------------
+# Section 6 — CollisionBounce callback (sub-critical like-charge oscillation)
+# ---------------------------------------------------------------------------
+println("\n[6] Sub-critical like-charge bounce (unregularized + CollisionBounce)")
+# Frauenfelder–Weber sub-critical regime: like-sign charges fall in through
+# near-zero separation (Weber's velocity term overcomes Coulomb repulsion).
+# CollisionBounce reflects the relative coordinate when r < bounce_r,
+# C⁰-continuing the head-on (ℓ=0) collision. Bounded energy error requires
+# a dt small enough that the bounce fires before the projection diverges
+# (validated: dt=1e-4 with bounce_r=0.02 → ~0.01% drift over 100 periods).
+m_b = 1.0
+q_b = 1.0
+c_b = 4.0
+r0_b = 0.05
+mu_b = m_b * m_b / (m_b + m_b)
+rho_b = q_b * q_b / (mu_b * c_b^2)
+T_b = (2π / c_b) * rho_b
+sys_b = HamiltonianSystem(2, 2)
+prob_b = HamiltonianProblem(
+    sys_b,
+    (0.0, 3 * T_b),
+    [r0_b / 2, 0.0, -r0_b / 2, 0.0],
+    [0.0, 0.0, 0.0, 0.0];
+    masses = [m_b, m_b],
+    charges = [q_b, q_b],
+    c = c_b,
+    dt = 1e-4,
+)
+sol_b = solve(prob_b, SymmetricProjectionIntegrator(); callbacks = CollisionBounce(0.02))
+en_b = compute_energy_timeseries(sol_b)
+ΔE_b = abs(en_b.statistics.global_error_percent_max)
+@printf "  retcode=%s  steps=%d  max global energy drift = %.3e %%\n" sol_b.retcode length(
+    sol_b.t,
+) ΔE_b
+
+# ---------------------------------------------------------------------------
+# Section 7 — RegularizedIntegrator synthesises a CollisionBounce automatically
+# ---------------------------------------------------------------------------
+println("\n[7] collision_bounce_radius kwarg synthesises an equivalent callback")
+alg_synth = RegularizedIntegrator(
+    SymmetricProjectionIntegrator();
+    backend = :adaptive_cartesian,
+    r_on = 0.001,
+    r_off = 0.002,
+    warn_on_fallback = false,
+    collision_bounce_radius = 0.02,
+)
+integrator = init(prob_b, alg_synth)
+@printf "  integrator.callbacks length = %d (auto-synthesised)\n" length(
+    integrator.callbacks,
+)
+@printf "  integrator.callbacks[1] isa CollisionBounce = %s\n" (
+    integrator.callbacks[1] isa CollisionBounce
+)
+@printf "  radius = %g\n" integrator.callbacks[1].radius
+
+# Synthesised vs explicit CollisionBounce on a regularized integrator should
+# match bit-for-bit (proven by `equivalence: collision_bounce_radius
+# synthesises CollisionBounce` testset in test/test_callbacks.jl).
+alg_explicit = RegularizedIntegrator(
+    SymmetricProjectionIntegrator();
+    backend = :adaptive_cartesian,
+    r_on = 0.001,
+    r_off = 0.002,
+    warn_on_fallback = false,
+)
+sol_synth = solve(prob_b, alg_synth)
+sol_explicit = solve(prob_b, alg_explicit; callbacks = CollisionBounce(0.02))
+max_dq = maximum(
+    maximum(abs, sol_synth.q[i] .- sol_explicit.q[i]) for i in eachindex(sol_synth.q)
+)
+max_dp = maximum(
+    maximum(abs, sol_synth.p[i] .- sol_explicit.p[i]) for i in eachindex(sol_synth.p)
+)
+@printf "  bit-exact match against explicit CollisionBounce: max|Δq|=%.2e max|Δp|=%.2e\n" max_dq max_dp
+
+println("\n" * "=" ^ 72)
+println("All sections completed cleanly.")


### PR DESCRIPTION
## Summary

The pre-v0.5.0 audit identified that `examples/two_body_reference.ipynb` only exercises a small slice of the new API. This PR adds a comprehensive showcase notebook (and a plain-script mirror) covering every surface introduced or reshaped by the layered refactor.

### Sections

1. **Custom Hamiltonian** via `HamiltonianSystem(H, q, p; …)` with `kinetic_term + coulomb_term` — pure Coulomb, no Weber velocity term, integrated through one Kepler period.
2. **Term introspection** — `term_names`, `has_term`, `get_term`, and the per-term `pair_decomposition` closure.
3. **Accessor tour** — every public accessor (`masses`, `charges`, `speed_of_light`, `kappas`, `kappa(prob, i, j)`, `params`, `n_particles`, `dims`) with a runtime proof that `masses(prob)` is an O(1) view (`parent(masses(prob)) === params(prob)`).
4. **N = 3 with charges `[+1, 0, -1]`** under Zöllner — confirms the documented `sign(0.0) == 0.0` semantics where neutral pairs receive κ = 1 + a.
5. **3D regularization** with `:adaptive_cartesian`, exposing the diagnostics (`activation_count`, `active_steps`, `total_substeps`, `min_encounter_distance`).
6. **`CollisionBounce` callback** on a sub-critical like-charge oscillation — uses the validated `dt = 1e-4`, `bounce_r = 0.02` setup from [`_research/Investigations/CollisionBounceRegularization.md`](_research/Investigations/CollisionBounceRegularization.md). Achieves ~1.4×10⁻² % global energy drift over 3 periods.
7. **`collision_bounce_radius` synthesis** — `RegularizedIntegrator(…; collision_bounce_radius = 0.02)` produces a callback that matches an explicit `CollisionBounce` bit-for-bit.

### Files

- [examples/api_showcase.ipynb](examples/api_showcase.ipynb) — Jupyter notebook (17 cells: 8 markdown + 9 code).
- [examples/api_showcase.jl](examples/api_showcase.jl) — plain-Julia mirror for headless verification.

## Test plan

- [x] `julia --project=. examples/api_showcase.jl` — every section completes with `retcode=Success` and the expected diagnostics. Verified locally.
- [x] Notebook JSON validated (17 cells, all parseable).
- [x] No source-code changes.
- [ ] Notebook outputs are intentionally empty — they re-populate on first execution in any IDE (Jupyter, VS Code, Pluto via include). Future PR could pre-execute via `nbconvert` once a CI runner has Jupyter installed.
- [ ] CI green on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)