### PR TITLE
feat: 3D KS regularization, parametric refactor, and v0.5.1 prep

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,9 @@ Regularization and collision bounce are composed outside the problem:
 - **Algorithm wrapper**: `RegularizedIntegrator(SymmetricProjectionIntegrator(); backend=:lifted_pair|:adaptive_cartesian, r_on_factor=..., r_off_factor=..., max_substeps=..., ...)`.
   Pass to `solve(prob, alg)`.
 - **Callback**: `CollisionBounce(radius)` passed via `solve(prob, alg; callbacks=CollisionBounce(r))`.
-- Regularization backends: `:adaptive_cartesian` (2D+3D) and `:lifted_pair` (2D only). Neither regularizes Weber's velocity-dependent force.
+- Regularization backends: `:adaptive_cartesian` (1D/2D/3D Cartesian substeps)
+  and `:lifted_pair` (1D square-root, 2D Levi-Civita, 3D KS binary pair
+  charts). Neither analytically regularizes Weber's velocity-dependent force.
 
 ### Accessor API
 

--- a/Project.toml
+++ b/Project.toml
@@ -11,11 +11,13 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [weakdeps]
+JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 
 [extensions]
+WeberElectrodynamicsJLD2Ext = "JLD2"
 WeberElectrodynamicsMakieExt = "Makie"
 WeberElectrodynamicsPlotsExt = ["Plots", "LaTeXStrings"]
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,25 @@ A Julia package for symplectic numerical integration of n-body Weber electrodyna
 
 - **WeberElectrodynamicsPlotsExt** — static plotting of trajectories, energy, forces, momentum and phase space
 - **WeberElectrodynamicsMakieExt** — real-time animated dashboard with any Makie backend (GLMakie, CairoMakie, WGLMakie)
+- **WeberElectrodynamicsJLD2Ext** — optional `HamiltonianSolution` archives via JLD2
+
+## Regularization capability matrix
+
+Regularization is opt-in through `RegularizedIntegrator`. The lifted backend
+regularizes binary close encounters by dimension; chain encounters still use
+adaptive Cartesian sub-stepping.
+
+| Situation | Backend | Status |
+| --- | --- | --- |
+| 1D binary close encounter | `:lifted_pair` | Lifted square-root chart |
+| 2D binary close encounter | `:lifted_pair` | Lifted Levi-Civita chart |
+| 3D binary close encounter | `:lifted_pair` | Lifted KS chart with constraint projection diagnostics |
+| Any dimension binary fallback | `:adaptive_cartesian` | Cartesian close-encounter substeps |
+| Multi-particle close cluster | chain mode | Adaptive Cartesian substeps over the active component |
+
+The regularization machinery handles the Coulomb/Kepler singular part. Weber's
+velocity-dependent correction is evaluated through the existing equations of
+motion and is not analytically regularized.
 
 ## Examples
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,2 +1,22 @@
-<!-- Add release notes here before running ./release.sh -->
-<!-- This file is cleared automatically on each release execute -->
+### Added
+
+- **3D KS Regularization.** The `:lifted_pair` backend now supports Kustaanheimo-Stiefel (KS) regularization in 3D, providing analytical resolution of close encounters for binary pairs in three dimensions.
+- **1D Square-root Regularization.** Added a 1D lifted-pair backend for head-on collisions, completing the dimension-specific regularization suite (1D, 2D, 3D).
+- **Parametric Type Refactor.** `HamiltonianProblem`, `HamiltonianSolution`, and `HamiltonianIntegrator` are now parametric on their system and problem types, enabling better compiler specialisation and significantly reducing dynamic dispatch in the integrator inner loops.
+- **Sparse Saving and Streaming.** Added `save_stride` (or `save_every`) to `solve`/`init` to control the frequency of state snapshots, and a `stream_sink` callback to process states in real-time without storing the full trajectory.
+- **Conservation Summary.** New `conservation_summary(sol)` utility providing a compact report of energy errors, momentum drift, and regularization diagnostics for quick verification.
+- **Solution Archiving.** Integrated `save_solution` and `load_solution` helpers (requiring JLD2.jl) for easy persistence of simulation results including all metadata.
+
+### Fixed
+
+- **Regularization substepping logic.** Corrected incorrect time-offset accumulation in the `RegularizedIntegrator` substepping loop.
+- **LC map singularity at origin.** The Levi-Civita projection `_lc_project!` now preserves momentum when `r ≈ 0`, preventing numerical NaN during exact head-on encounters.
+- **Zöllner κ logic for neutral particles.** Charge pairs where at least one particle is neutral (`q = 0`) now correctly receive `κ = 1.0` instead of `1 + a`.
+- **Animation dashboard stability.** Fixed several issues in `animate_weber` circular buffer handling and phase-space selection.
+- **Kappa accessor robustness.** `kappa(prob, i, j)` now automatically handles index ordering (supports `j < i`).
+
+### Changed
+
+- **Regularization diagnostics validation.** Regression fixtures now include 16 fields of regularization diagnostics (substep counts, backend fallbacks, constraint violations), ensuring numerical equivalence of the regularization state.
+- **Trail length slider.** The `animate_weber` trail-length slider now includes a log-linear range.
+- **Release script safety.** `release.sh` now verifies the active `gh` account and uses a robust Python-based version bump.

--- a/docs/src/api/problem.md
+++ b/docs/src/api/problem.md
@@ -26,7 +26,26 @@ lives on its own field of length `N(N−1)/2`, separate from `params`.
 See also `n_particles(prob)` and `dims(prob)`, documented on the [System](system.md) page.
 
 ```@docs
+masses
+charges
+speed_of_light
+kappas
 kappa
+params
+```
+
+## Initial-condition helpers
+
+These helpers return named tuples with flattened `q` and `p` vectors ready for
+`HamiltonianProblem`. Helpers that infer Coulomb scales accept explicit `kappa`
+or `kappas` values; `ZollnerOptions` itself is still applied at problem
+construction time.
+
+```@docs
+center_of_mass_frame
+two_body_initial_conditions
+polygon_initial_conditions
+rigid_rotation_initial_conditions
 ```
 
 ## Optional features

--- a/docs/src/api/solver.md
+++ b/docs/src/api/solver.md
@@ -22,3 +22,21 @@ HamiltonianSolution
 SymmetricProjectionIntegrator
 RegularizedIntegrator
 ```
+
+## Archives
+
+JLD2 archive helpers are provided by an optional extension. They currently
+archive default Weber/Zöllner systems by storing primitive solution arrays and
+problem metadata, then reconstructing the system on load. Load `JLD2` before
+calling them:
+
+```julia
+using WeberElectrodynamics, JLD2
+save_solution("run.jld2", sol; metadata = (case = "two-body",))
+sol2 = load_solution("run.jld2")
+```
+
+```@docs
+save_solution
+load_solution
+```

--- a/docs/src/api/statistics.md
+++ b/docs/src/api/statistics.md
@@ -1,5 +1,10 @@
 # Statistics
 
+For generic custom Hamiltonians, `compute_energy_timeseries` evaluates the
+compiled total Hamiltonian and kinetic split. Full pair decompositions are
+available when the system includes built-in Weber/Zöllner `NamedTerm`
+decomposition closures.
+
 ## Trajectories
 
 ```@docs
@@ -14,6 +19,7 @@ EnergyData
 PairEnergyData
 EnergyStatistics
 compute_energy_timeseries
+conservation_summary
 ```
 
 ## Forces

--- a/docs/src/api/system.md
+++ b/docs/src/api/system.md
@@ -59,6 +59,8 @@ Shape accessors are defined for both `HamiltonianSystem` and `HamiltonianProblem
 
 ```@docs
 n_particles
+n_pairs
+pair_indices
 ```
 
 | Function | Returns |

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -5,8 +5,8 @@ A Julia package for n-body simulation of charged particles interacting via Weber
 ## Features
 
 - **Symplectic integrator** — Extended phase space semi-explicit symplectic integrator for non-separable Hamiltonians with Strang-splitting and symmetric projection ([Jayawardana & Ohsawa 2021](https://arxiv.org/abs/2111.10915)).
-- **Regularization** — Levi-Civita/KS for close encounters in 2D; adaptive
-  Cartesian substeps in 3D. Chain regularization for multi-particle encounters.
+- **Regularization** — Lifted square-root (1D), Levi-Civita (2D), and KS (3D)
+  pair regularization; adaptive Cartesian substeps for chain encounters.
 - **Statistics** — energy, force, momentum, and trajectory analysis.
 - **Visualization** — Plots.jl extension for static figures; Makie extension
   for interactive real-time and replay animation.
@@ -23,4 +23,3 @@ Pkg.add("WeberElectrodynamics")
 - [Quick Start](@ref) — minimal working example
 - [API Reference](@ref "System") — complete type and function documentation
 - [Theory](@ref) — links to derivations and design documents
-

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -8,7 +8,8 @@ Reference for contributors, developers, and AI agents working with WeberElectrod
 
 ### Source files (`src/`)
 
-- `WeberElectrodynamics.jl` — Module definition, exports, extension stubs (`plot_*`, `animate_weber`)
+- `WeberElectrodynamics.jl` — Module definition, exports, extension stubs (`plot_*`, `animate_weber`, archive helpers)
+- `initial_conditions.jl` — COM-frame two-body, polygon, and rigid-rotation initial-condition helpers
 - `hamiltonian_system.jl` — `HamiltonianSystem`: uses Symbolics.jl to build the Weber Hamiltonian symbolically, then compiles `dq_dt`, `dp_dt`, and `hamiltonian` functions via `build_function`
 - `types.jl` — All core structs: `HamiltonianProblem`, `HamiltonianSolution`, `HamiltonianIntegrator`, `SymmetricProjectionIntegrator`, `RegularizationOptions`, `ZollnerOptions`, buffer/diagnostics types
 - `regularization.jl` — Internal helpers: pair distance detection, adjacency graph (BFS), Levi-Civita 2D projection, KS quaternion helpers
@@ -19,12 +20,13 @@ Reference for contributors, developers, and AI agents working with WeberElectrod
 
 - `WeberElectrodynamicsPlotsExt.jl` — Plots.jl weak dependency; provides `plot_trajectories`, `plot_energy`, `plot_pair_energy`, `plot_energy_errors`, `plot_pair_forces`, `plot_phase_space`, `plot_momentum_errors`, and Zöllner-specific plot functions.
 - `WeberElectrodynamicsMakieExt.jl` — Makie weak dependency (any backend: GLMakie, CairoMakie, WGLMakie); provides `animate_weber` for real-time streaming or solution replay with rolling trajectory/energy/momentum/phase-space dashboard.
+- `WeberElectrodynamicsJLD2Ext.jl` — JLD2 weak dependency; provides `save_solution` and `load_solution`.
 
 ### Tests (`test/`)
 
 - `test_utils.jl` — Problem builders (`make_weber_problem()`, `make_coulomb_like_problem()`) and reference energy functions; **must be included before other test files**
 - `runtests.jl` — Entry point, includes all test files in order
-- Test files: `test_types.jl`, `test_hamiltonian_system.jl`, `test_solve.jl`, `test_statistics.jl`, `test_integration.jl`, `test_physics.jl`, `test_regularization.jl`, `test_zollner.jl`
+- Test files: `test_types.jl`, `test_hamiltonian_system.jl`, `test_initial_conditions.jl`, `test_solve.jl`, `test_statistics.jl`, `test_integration.jl`, `test_physics.jl`, `test_regularization.jl`, `test_zollner.jl`
 
 ### Examples (`examples/`)
 
@@ -76,17 +78,19 @@ Pair index (internal): `_pair_index(i, j, n) = (i-1)*(2n-i)÷2 + (j-i)` (1-based
 ### Regularization backends
 
 Only two valid values for `RegularizationOptions.backend`:
-- `:adaptive_cartesian` — KS-style, works for all dimensions
-- `:lifted_pair` — Levi-Civita, **2D only** (auto-falls back to `:adaptive_cartesian` outside 2D)
+- `:adaptive_cartesian` — Cartesian close-encounter substeps, works for all dimensions
+- `:lifted_pair` — lifted square-root (1D), Levi-Civita (2D), or KS (3D) binary pair stepping
 
-Neither backend regularizes Weber's velocity-dependent force — only the Coulomb/Kepler singularity.
+Multi-particle close clusters use chain mode, which is adaptive Cartesian over
+the active component. Neither backend analytically regularizes Weber's
+velocity-dependent force — only the Coulomb/Kepler singularity.
 
 ### Collision bounce
 
 - Implemented as the `CollisionBounce(radius)` callback; pass it to `solve` (or `init`) via the `callbacks` kwarg
 - `RegularizedIntegrator` also accepts a `collision_bounce_radius` kwarg and synthesises a matching callback automatically when no `CollisionBounce` is supplied
+- Under `RegularizedIntegrator`, the bounce radius is checked after regularized substeps as well as at macro-step boundaries
 - Only valid for ℓ=0 (head-on) collisions
-- Works best with the **unregularized** integrator (symplectic error stays bounded)
 
 ### Zöllner extension
 

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -87,6 +87,16 @@ p0 = [0.0, p_circ, 0.0, -p_circ]
 p0  = p0 .* η_v
 ```
 
+The helper API provides the same COM setup directly:
+
+```julia
+ic = two_body_initial_conditions([m1, m2], [q1, q2];
+    separation = r0,
+    velocity_scale = η_v,
+)
+q0, p0 = ic.q, ic.p
+```
+
 ### N-body symmetric polygon
 
 Place N particles at regular N-gon vertices of circumradius `R` with alternating charges ±Q.
@@ -123,7 +133,7 @@ energy = compute_energy_timeseries(sol)
 println("Max energy drift: ", energy.statistics.global_error_percent_max, " %")
 
 # Trajectory data
-traj = compute_trajectory_data(sol, 2, 2)
+traj = compute_trajectory_data(sol)
 
 # Plotting (requires Plots.jl)
 using Plots
@@ -146,7 +156,7 @@ sol = solve!(integrator)
 ```julia
 using Plots
 
-traj     = compute_trajectory_data(sol, 2, 2)
+traj     = compute_trajectory_data(sol)
 energy   = compute_energy_timeseries(sol)
 momentum = compute_momentum_timeseries(sol)
 
@@ -169,9 +179,9 @@ animate_weber(sol)    # replay
 The integrator above runs the core unregularized symplectic method. Two optional
 extensions can be enabled explicitly:
 
-- **[Regularization](regularization.md)** — Levi-Civita / KS handling for
-  close encounters. Wrap the base algorithm:
-  `solve(prob, RegularizedIntegrator(SymmetricProjectionIntegrator()))`.
+- **[Regularization](regularization.md)** — lifted square-root (1D),
+  Levi-Civita (2D), and KS (3D) pair handling for close encounters. Wrap the
+  base algorithm: `solve(prob, RegularizedIntegrator())`.
 - **[Zöllner Extension](zollner.md)** — research feature implementing Zöllner's
   electrogravitational mismatch hypothesis. Pass
   `zollner = ZollnerOptions(enabled = true, a = <value>)` to `HamiltonianProblem`.

--- a/docs/src/regularization.md
+++ b/docs/src/regularization.md
@@ -15,8 +15,9 @@ regularization when:
 - You observe energy drift or `NaN` values near close passages without it.
 
 Regularization handles the Coulomb/Kepler singularity only. Weber's
-velocity-dependent correction is **not** regularized — the LC and KS transforms
-apply to the conservative part of the force.
+velocity-dependent correction is **not analytically regularized**; it is still
+evaluated through the package's equations of motion during regularized
+substeps.
 
 ## Enabling regularization
 
@@ -41,21 +42,24 @@ set implicitly).
 
 | Backend | Symbol | Dimensions | Method |
 |---------|--------|-----------|--------|
-| Levi-Civita (default) | `:lifted_pair` | **2D only** | Lifts the pair to ℝ⁴ fictitious time |
-| Adaptive Cartesian | `:adaptive_cartesian` | 2D and 3D | Cartesian sub-stepping with KS constraint |
+| Lifted pair (default) | `:lifted_pair` | 1D | Square-root chart with fictitious time |
+| Lifted pair (default) | `:lifted_pair` | 2D | Levi-Civita pair chart with fictitious time |
+| Lifted pair (default) | `:lifted_pair` | 3D | KS pair chart with constraint projection diagnostics |
+| Adaptive Cartesian | `:adaptive_cartesian` | 1D, 2D, 3D | Cartesian close-encounter substeps |
+| Chain mode | automatic | 1D, 2D, 3D | Adaptive Cartesian substeps over multi-particle close clusters |
 
-For 3D problems, `:lifted_pair` automatically falls back to `:adaptive_cartesian`
-(with an optional warning controlled by `warn_on_fallback`).
+`RegularizedIntegrator(; kwargs...)` is shorthand for wrapping
+`SymmetricProjectionIntegrator()`.
 
 !!! note "3D KS constraint"
-    The `:adaptive_cartesian` backend applies a one-pass KS constraint projection
-    at each close-encounter lift, then runs a Cartesian sub-step. The constraint
-    is not iterated to convergence within the sub-step; `max_constraint_violation`
-    in the diagnostics tracks the residual. For current 2D-heavy use cases this
-    is sufficient. True iterative 3D KS stepping is deferred to a future release.
+    The `:lifted_pair` backend uses a KS pair chart and projects the KS momentum
+    constraint at the start, midpoint, and end of each lifted substep. The
+    diagnostics report both `max_constraint_violation` and KS projection counts.
+    The `:adaptive_cartesian` backend still uses KS lifts for diagnostics only
+    before running Cartesian substeps.
 
 ```julia
-# Explicit 3D choice
+# Explicit Cartesian fallback choice
 alg = RegularizedIntegrator(
     SymmetricProjectionIntegrator();
     backend = :adaptive_cartesian,
@@ -88,15 +92,16 @@ sol = solve(prob, alg)
 ## Chain mode
 
 When three or more particles form a connected close-encounter cluster,
-regularization falls back to chain mode (adaptive Cartesian substeps for the
-whole cluster). Chain mode is enabled by default; disable with
+regularization enters chain mode (adaptive Cartesian substeps for the whole
+cluster). Chain mode is enabled by default; disable with
 `RegularizedIntegrator(...; chain_enabled = false)`.
 
 ## Collision bounce
 
-For head-on (ℓ = 0) collisions between like-charge pairs, a reflection
-boundary can be applied before each macro-step. This avoids the non-regularizable
-ℓ ≠ 0 singularity (where particles reach r = 0 at infinite speed).
+For head-on (ℓ = 0) collisions between like-charge pairs, a reflection boundary
+can be applied before each macro-step. Under `RegularizedIntegrator`, the same
+radius is also checked after regularized substeps, so close approaches inside a
+regularized macro-step do not have to wait for the next outer step.
 
 Collision bounce is a [`CollisionBounce`](@ref) callback; pass it through the
 `callbacks` kwarg of `solve` (or `init`):
@@ -115,8 +120,8 @@ alg = RegularizedIntegrator(SymmetricProjectionIntegrator();
 sol = solve(prob, alg)
 ```
 
-Collision bounce works best **without** Levi-Civita regularization (the
-unregularized symplectic integrator keeps energy bounded across the bounce).
+Collision bounce is intended for C0-continuable head-on cases. It does not make
+generic nonzero-angular-momentum collisions regular.
 
 ## Diagnostics
 
@@ -138,7 +143,9 @@ Key fields and what they mean:
 | `activation_count` | How many times regularization switched on | Very high → r_off is too close to r_on |
 | `min_encounter_distance` | Closest particle approach over the run | Near 0 → singularity risk; consider bounce radius |
 | `max_constraint_violation` | Peak KS constraint residual (3D only) | > 1e-8 → reduce `dt` or `max_substeps` |
-| `backend_fallback_steps` | Steps that used the fallback backend | > 0 when `:lifted_pair` was requested on a 3D problem |
+| `ks_constraint_projection_count` | Number of KS constraint projections | Useful for confirming the 3D lifted path ran |
+| `ks_constraint_iteration_count` | Total KS projection iterations | Higher than projections if future iterative correction is enabled |
+| `backend_fallback_steps` | Steps that used the fallback backend | > 0 only when a requested backend is unavailable |
 | `total_substeps` | Total regularization micro-steps taken | Very large → consider wider r_on/r_off thresholds |
 
 ## API reference

--- a/examples/api_showcase.ipynb
+++ b/examples/api_showcase.ipynb
@@ -12,7 +12,7 @@
     "2. **Term introspection** — `term_names`, `has_term`, `get_term`, and the per-term `pair_decomposition` closure.\n",
     "3. **Accessor tour** — `masses`, `charges`, `speed_of_light`, `kappas`, `kappa(prob, i, j)`, `params`, plus the shape accessors. Includes proof that `masses(prob)` is an O(1) view into `params(prob)`.\n",
     "4. **N = 3 with mixed charges and a neutral particle** under Zöllner — verifies that neutral pairs keep κ = 1 while opposite nonzero signs receive κ = 1 + a.\n",
-    "5. **3D regularization** with the `:adaptive_cartesian` backend (the only one supported in 3D).\n",
+    "5. **3D lifted KS regularization** with the `:lifted_pair` backend.\n",
     "6. **`CollisionBounce` callback** on its own — sub-critical like-charge oscillation in 2D.\n",
     "7. **Combined regularization + bounce** — `RegularizedIntegrator` synthesises a `CollisionBounce` from the `collision_bounce_radius` kwarg, matching an explicit one bit-for-bit.\n",
     "\n",
@@ -216,9 +216,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 5 — 3D regularization with `:adaptive_cartesian`\n",
+    "## 5 — 3D lifted KS regularization with `:lifted_pair`\n",
     "\n",
-    "The `:lifted_pair` Levi-Civita backend is 2D-only and auto-falls back to `:adaptive_cartesian` for 3D (with a warning unless `warn_on_fallback = false`). `:adaptive_cartesian` is the only 3D-supported backend; this cell exercises it on a 2-body close approach.\n",
+    "The `:lifted_pair` backend uses a dimension-specific chart: square-root in 1D, Levi-Civita in 2D, and KS in 3D. This cell exercises the 3D KS pair path on a 2-body close approach.\n",
     "\n",
     "The regularization diagnostics on the returned solution count activations, substeps, and the closest encounter."
    ]
@@ -258,7 +258,7 @@
     ")\n",
     "alg_3d = RegularizedIntegrator(\n",
     "    SymmetricProjectionIntegrator();\n",
-    "    backend = :adaptive_cartesian,\n",
+    "    backend = :lifted_pair,\n",
     "    r_on_factor = 0.3,\n",
     "    r_off_factor = 0.45,\n",
     "    warn_on_fallback = false,\n",
@@ -270,7 +270,9 @@
     "@printf \"activation_count   = %d\\n\" diag.activation_count\n",
     "@printf \"active_steps       = %d\\n\" diag.active_steps\n",
     "@printf \"total_substeps     = %d\\n\" diag.total_substeps\n",
-    "@printf \"min encounter dist = %.3e\\n\" diag.min_encounter_distance"
+    "@printf \"min encounter dist = %.3e\\n\" diag.min_encounter_distance\n",
+    "@printf \"KS projections     = %d\\n\" diag.ks_constraint_projection_count\n",
+    "@printf \"max KS constraint  = %.3e\\n\" diag.max_constraint_violation"
    ]
   },
   {
@@ -281,7 +283,7 @@
     "\n",
     "Frauenfelder–Weber sub-critical regime: like-sign charges fall in through near-zero separation (Weber's velocity term overcomes Coulomb repulsion). The `CollisionBounce(r)` pre-step callback reflects the relative coordinate when the pair separation drops below `r`, providing a $C^0$ continuation of the head-on (ℓ = 0) collision (Frauenfelder & Weber 2024).\n",
     "\n",
-    "The validated parameters (see `_research/Investigations/CollisionBounceRegularization.md`) use absolute `dt = 1e-4` (not period-scaled) with `bounce_r = 0.02`, giving ~0.01 % global energy drift over 100 periods. We run 3 periods here."
+    "The validated parameters use absolute `dt = 1e-4` (not period-scaled) with `bounce_r = 0.02`, giving bounded global energy drift over long runs. We run 3 periods here."
    ]
   },
   {

--- a/examples/api_showcase.jl
+++ b/examples/api_showcase.jl
@@ -10,7 +10,7 @@
 #   2. Term introspection (`term_names`, `has_term`, `pair_decomposition`)
 #   3. Accessor tour
 #   4. N=3 mixed signs with a neutral particle (Zöllner)
-#   5. 3D regularization with `:adaptive_cartesian`
+#   5. 3D lifted KS regularization with `:lifted_pair`
 #   6. CollisionBounce callback
 #   7. Combined RegularizedIntegrator + CollisionBounce
 #
@@ -150,9 +150,9 @@ sol_n3 = solve(prob_n3)
 @printf "  retcode=%s  steps=%d\n" sol_n3.retcode length(sol_n3.t)
 
 # ---------------------------------------------------------------------------
-# Section 5 — 3D regularization with :adaptive_cartesian
+# Section 5 — 3D lifted KS regularization with :lifted_pair
 # ---------------------------------------------------------------------------
-println("\n[5] 3D close approach with :adaptive_cartesian regularization")
+println("\n[5] 3D close approach with :lifted_pair KS regularization")
 sys_3d = HamiltonianSystem(2, 3)
 m1_3d, m2_3d = 1.0, 0.1
 q1_3d, q2_3d = sqrt(0.1), -sqrt(0.1)
@@ -175,7 +175,7 @@ prob_3d = HamiltonianProblem(
 )
 alg_3d = RegularizedIntegrator(
     SymmetricProjectionIntegrator();
-    backend = :adaptive_cartesian,
+    backend = :lifted_pair,
     r_on_factor = 0.3,
     r_off_factor = 0.45,
     warn_on_fallback = false,
@@ -184,6 +184,7 @@ sol_3d = solve(prob_3d, alg_3d)
 diag = sol_3d.regularization
 @printf "  retcode=%s  steps=%d\n" sol_3d.retcode length(sol_3d.t)
 @printf "  regularization: backend=%s activations=%d active_steps=%d total_substeps=%d min_r=%.3e\n" diag.used_backend diag.activation_count diag.active_steps diag.total_substeps diag.min_encounter_distance
+@printf "  KS projections=%d  max constraint violation=%.3e\n" diag.ks_constraint_projection_count diag.max_constraint_violation
 
 # ---------------------------------------------------------------------------
 # Section 6 — CollisionBounce callback (sub-critical like-charge oscillation)

--- a/ext/WeberElectrodynamicsJLD2Ext.jl
+++ b/ext/WeberElectrodynamicsJLD2Ext.jl
@@ -1,0 +1,143 @@
+module WeberElectrodynamicsJLD2Ext
+
+using JLD2
+using WeberElectrodynamics
+
+function _diagnostics_to_archive(d::WeberElectrodynamics.RegularizationDiagnostics)
+    return (
+        enabled = d.enabled,
+        requested_backend = d.requested_backend,
+        used_backend = d.used_backend,
+        activation_count = d.activation_count,
+        deactivation_count = d.deactivation_count,
+        active_steps = d.active_steps,
+        pair_steps = d.pair_steps,
+        adaptive_pair_steps = d.adaptive_pair_steps,
+        lifted_pair_steps = d.lifted_pair_steps,
+        chain_steps = d.chain_steps,
+        unregularized_steps = d.unregularized_steps,
+        backend_fallback_steps = d.backend_fallback_steps,
+        total_substeps = d.total_substeps,
+        max_substeps_used = d.max_substeps_used,
+        max_constraint_violation = d.max_constraint_violation,
+        ks_constraint_projection_count = d.ks_constraint_projection_count,
+        ks_constraint_iteration_count = d.ks_constraint_iteration_count,
+        min_encounter_distance = d.min_encounter_distance,
+        mode_history = copy(d.mode_history),
+    )
+end
+
+function _diagnostics_from_archive(data, n_steps::Int)
+    d = WeberElectrodynamics.RegularizationDiagnostics(
+        data.enabled,
+        n_steps,
+        data.requested_backend,
+        data.used_backend,
+    )
+    d.activation_count = data.activation_count
+    d.deactivation_count = data.deactivation_count
+    d.active_steps = data.active_steps
+    d.pair_steps = data.pair_steps
+    d.adaptive_pair_steps = data.adaptive_pair_steps
+    d.lifted_pair_steps = data.lifted_pair_steps
+    d.chain_steps = data.chain_steps
+    d.unregularized_steps = data.unregularized_steps
+    d.backend_fallback_steps = data.backend_fallback_steps
+    d.total_substeps = data.total_substeps
+    d.max_substeps_used = data.max_substeps_used
+    d.max_constraint_violation = data.max_constraint_violation
+    d.ks_constraint_projection_count = data.ks_constraint_projection_count
+    d.ks_constraint_iteration_count = data.ks_constraint_iteration_count
+    d.min_encounter_distance = data.min_encounter_distance
+    n = min(length(data.mode_history), length(d.mode_history))
+    if n > 0
+        copyto!(d.mode_history, 1, data.mode_history, 1, n)
+    end
+    return d
+end
+
+function WeberElectrodynamics.save_solution(
+    path::AbstractString,
+    sol::WeberElectrodynamics.HamiltonianSolution;
+    metadata = NamedTuple(),
+)
+    prob = sol.prob
+    terms = WeberElectrodynamics.term_names(prob.system)
+    terms == [:weber, :zollner] || throw(
+        ArgumentError(
+            "save_solution currently archives default Weber/Zollner systems only; got terms=$terms",
+        ),
+    )
+
+    archive = (
+        format_version = 1,
+        problem = (
+            n_particles = WeberElectrodynamics.n_particles(prob),
+            dims = WeberElectrodynamics.dims(prob),
+            tspan = prob.tspan,
+            q_initial = copy(prob.q_initial),
+            p_initial = copy(prob.p_initial),
+            params = copy(WeberElectrodynamics.params(prob)),
+            kappas = copy(WeberElectrodynamics.kappas(prob)),
+            dt = prob.dt,
+            convergence_tolerance = prob.convergence_tolerance,
+            maximum_iterations = prob.maximum_iterations,
+            term_names = terms,
+        ),
+        solution = (
+            t = copy(sol.t),
+            q = [copy(q) for q in sol.q],
+            p = [copy(p) for p in sol.p],
+            retcode = sol.retcode,
+            regularization = _diagnostics_to_archive(sol.regularization),
+        ),
+        metadata = metadata,
+    )
+
+    JLD2.jldsave(path; archive = archive)
+    return path
+end
+
+function WeberElectrodynamics.load_solution(path::AbstractString)
+    data = JLD2.load(path)
+    haskey(data, "archive") ||
+        throw(ArgumentError("archive does not contain an `archive` entry"))
+    archive = data["archive"]
+    archive.format_version == 1 ||
+        throw(ArgumentError("unsupported solution archive format version"))
+
+    pdat = archive.problem
+    pdat.term_names == [:weber, :zollner] ||
+        throw(ArgumentError("cannot reconstruct archived custom Hamiltonian system"))
+
+    system = WeberElectrodynamics.HamiltonianSystem(pdat.n_particles, pdat.dims)
+    prob = WeberElectrodynamics.HamiltonianProblem(
+        system,
+        pdat.tspan,
+        Vector{Float64}(pdat.q_initial),
+        Vector{Float64}(pdat.p_initial),
+        Vector{Float64}(pdat.params),
+        Vector{Float64}(pdat.kappas),
+        Float64(pdat.dt),
+        Float64(pdat.convergence_tolerance),
+        Int(pdat.maximum_iterations),
+    )
+
+    sdat = archive.solution
+    t = Vector{Float64}(sdat.t)
+    q = [Vector{Float64}(state) for state in sdat.q]
+    p = [Vector{Float64}(state) for state in sdat.p]
+    diagnostics =
+        _diagnostics_from_archive(sdat.regularization, length(sdat.regularization.mode_history))
+
+    return WeberElectrodynamics.HamiltonianSolution(
+        t,
+        q,
+        p,
+        prob,
+        sdat.retcode,
+        diagnostics,
+    )
+end
+
+end

--- a/src/WeberElectrodynamics.jl
+++ b/src/WeberElectrodynamics.jl
@@ -11,7 +11,7 @@ export @sprintf, norm, dot
 include("hamiltonian_system.jl")
 export HamiltonianSystem, weber_term, zollner_term, kinetic_term, coulomb_term
 export NamedTerm, term_names, has_term, get_term
-export n_particles, dims, degrees_of_freedom
+export n_particles, dims, degrees_of_freedom, n_pairs, pair_indices
 
 # =============================================================================
 # Core Types (Problem, Solution, Integrator)
@@ -25,6 +25,14 @@ export RegularizationDiagnostics
 export ZollnerOptions
 export SymmetricProjectionIntegrator
 export masses, charges, speed_of_light, kappas, kappa, params
+
+# =============================================================================
+# Initial-condition helpers
+# =============================================================================
+include("initial_conditions.jl")
+export center_of_mass_frame
+export two_body_initial_conditions, polygon_initial_conditions
+export rigid_rotation_initial_conditions
 
 # =============================================================================
 # Regularization Helpers
@@ -64,6 +72,13 @@ export EnergyData
 export PairEnergyData
 export EnergyStatistics
 export compute_energy_timeseries
+export conservation_summary
+
+# =============================================================================
+# Persistence
+# =============================================================================
+include("archive.jl")
+export save_solution, load_solution
 
 include("statistics/forces.jl")
 export PairForceData

--- a/src/archive.jl
+++ b/src/archive.jl
@@ -1,0 +1,25 @@
+"""
+    save_solution(path, sol; metadata=NamedTuple())
+
+Save a [`HamiltonianSolution`](@ref) to a JLD2 archive.
+
+The archive stores primitive solution arrays plus problem metadata for default
+Weber/Zöllner systems. Custom symbolic Hamiltonians are not reconstructable by
+this helper yet.
+
+This function is implemented by the optional JLD2 extension. Load it with
+`using JLD2` before calling `save_solution`.
+"""
+function save_solution end
+
+"""
+    load_solution(path) -> HamiltonianSolution
+
+Load a [`HamiltonianSolution`](@ref) from a JLD2 archive created by
+[`save_solution`](@ref). The default Weber/Zöllner `HamiltonianSystem` is
+reconstructed from the archived metadata.
+
+This function is implemented by the optional JLD2 extension. Load it with
+`using JLD2` before calling `load_solution`.
+"""
+function load_solution end

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -41,8 +41,8 @@ the unregularized symplectic path. Under `RegularizedIntegrator`, the callback
 fires only at macro-step boundaries; close approaches inside regularized
 substeps are not reflected until the next outer step.
 
-See `docs/exploratory/CollisionBounceRegularization.md` for the full physics
-motivation and validation.
+See `docs/src/regularization.md` and `theory/Regularization.md` for the
+regularization and collision-continuation context.
 """
 struct CollisionBounce <: HamiltonianCallback
     radius::Float64

--- a/src/hamiltonian/terms.jl
+++ b/src/hamiltonian/terms.jl
@@ -8,16 +8,16 @@ contributing to the total `H`. Stored on `HamiltonianSystem` as
 contributions without re-deriving them from the compiled aggregate.
 
 The optional `pair_decomposition` closure returns a per-pair decomposition of
-the term's contribution, evaluated on concrete `(i, j, q, p, params)` inputs.
-The shape of the returned tuple is term-specific; the Weber and Zöllner
-builders will attach compatible closures in Phase 4 when statistics migrate
-onto this interface.
+the term's contribution, evaluated on concrete
+`(i, j, q, p, params, kappas)` inputs. The shape of the returned tuple is
+term-specific. The built-in Weber and Zöllner builders attach compatible
+closures used by the pair energy and force diagnostics.
 
 # Fields
 - `name::Symbol`: Identifier used by `get_term`, `has_term`, `term_names`.
 - `H_symbolic`: Symbolic expression contributing to the aggregate Hamiltonian.
 - `pair_decomposition::Union{Function,Nothing}`: Optional closure
-  `(i, j, q, p, params) -> NamedTuple` for per-pair statistics.
+  `(i, j, q, p, params, kappas) -> NamedTuple` for per-pair statistics.
 """
 struct NamedTerm{H,F}
     name::Symbol

--- a/src/initial_conditions.jl
+++ b/src/initial_conditions.jl
@@ -1,0 +1,280 @@
+"""
+    center_of_mass_frame(q, p, masses, dims) -> NamedTuple
+
+Return `(q, p)` shifted into the centre-of-mass frame.
+
+Positions are translated so `sum(m_i * r_i) == 0`. Momenta are shifted by the
+centre-of-mass velocity so `sum(p_i) == 0`. Inputs are not mutated.
+"""
+function center_of_mass_frame(
+    q::AbstractVector{<:Real},
+    p::AbstractVector{<:Real},
+    masses_in::AbstractVector{<:Real},
+    dims_in::Integer,
+)
+    dims_value = Int(dims_in)
+    dims_value >= 1 || throw(ArgumentError("dims must be positive, got $dims_value"))
+
+    n = length(masses_in)
+    dof = n * dims_value
+    length(q) == dof ||
+        throw(ArgumentError("q must have length $dof for $n particles in $dims_value D"))
+    length(p) == dof ||
+        throw(ArgumentError("p must have length $dof for $n particles in $dims_value D"))
+
+    masses_vec = Vector{Float64}(masses_in)
+    all(m -> m > 0, masses_vec) ||
+        throw(ArgumentError("all masses must be positive"))
+
+    total_mass = sum(masses_vec)
+    q_out = Vector{Float64}(q)
+    p_out = Vector{Float64}(p)
+
+    com = zeros(Float64, dims_value)
+    total_p = zeros(Float64, dims_value)
+    @inbounds for i = 1:n
+        offset = (i - 1) * dims_value
+        mi = masses_vec[i]
+        for d = 1:dims_value
+            idx = offset + d
+            com[d] += mi * q_out[idx]
+            total_p[d] += p_out[idx]
+        end
+    end
+    @inbounds for d = 1:dims_value
+        com[d] /= total_mass
+        total_p[d] /= total_mass
+    end
+
+    @inbounds for i = 1:n
+        offset = (i - 1) * dims_value
+        mi = masses_vec[i]
+        for d = 1:dims_value
+            idx = offset + d
+            q_out[idx] -= com[d]
+            p_out[idx] -= mi * total_p[d]
+        end
+    end
+
+    return (q = q_out, p = p_out)
+end
+
+"""
+    two_body_initial_conditions(masses, charges; separation, dims=2,
+                                kappa=1.0, velocity_scale=1.0,
+                                radial_velocity=0.0) -> NamedTuple
+
+Construct centre-of-mass two-body initial conditions.
+
+The particles are placed on the x axis with separation `separation`. For
+`dims >= 2`, the transverse momentum is
+`velocity_scale * sqrt(mu * abs(kappa*q1*q2) / separation)`, where `mu` is the
+reduced mass. Set `velocity_scale=1` for the circular Coulomb scale and
+`radial_velocity=0` for zero initial radial velocity.
+
+Returns `(q, p, masses, charges)`.
+"""
+function two_body_initial_conditions(
+    masses_in::AbstractVector{<:Real},
+    charges_in::AbstractVector{<:Real};
+    separation::Real,
+    dims::Integer = 2,
+    kappa::Real = 1.0,
+    velocity_scale::Real = 1.0,
+    radial_velocity::Real = 0.0,
+)
+    length(masses_in) == 2 || throw(ArgumentError("masses must have length 2"))
+    length(charges_in) == 2 || throw(ArgumentError("charges must have length 2"))
+
+    dims_value = Int(dims)
+    1 <= dims_value <= 3 ||
+        throw(ArgumentError("dims must be 1, 2, or 3, got $dims_value"))
+    separation_value = Float64(separation)
+    separation_value > 0 ||
+        throw(ArgumentError("separation must be positive, got $separation"))
+
+    masses_vec = Vector{Float64}(masses_in)
+    charges_vec = Vector{Float64}(charges_in)
+    all(m -> m > 0, masses_vec) ||
+        throw(ArgumentError("all masses must be positive"))
+
+    mi, mj = masses_vec
+    total_mass = mi + mj
+    reduced_mass = mi * mj / total_mass
+
+    q = zeros(Float64, 2 * dims_value)
+    p = zeros(Float64, 2 * dims_value)
+
+    # q_rel = q1 - q2 points along +x and has norm `separation`.
+    q[1] = mj / total_mass * separation_value
+    q[dims_value+1] = -mi / total_mass * separation_value
+
+    rel_p = zeros(Float64, dims_value)
+    rel_p[1] = reduced_mass * Float64(radial_velocity)
+    if dims_value >= 2
+        pair_coupling = Float64(kappa) * charges_vec[1] * charges_vec[2]
+        circular_p = sqrt(reduced_mass * abs(pair_coupling) / separation_value)
+        rel_p[2] = Float64(velocity_scale) * circular_p
+    end
+
+    @inbounds for d = 1:dims_value
+        p[d] = rel_p[d]
+        p[dims_value+d] = -rel_p[d]
+    end
+
+    framed = center_of_mass_frame(q, p, masses_vec, dims_value)
+    return (q = framed.q, p = framed.p, masses = masses_vec, charges = charges_vec)
+end
+
+"""
+    polygon_initial_conditions(n; radius, mass=1.0, charge_magnitude=1.0,
+                               energy_ratio=0.5, speed=nothing,
+                               clockwise=false, kappas=nothing) -> NamedTuple
+
+Construct planar regular-polygon initial conditions with alternating charges.
+
+Particles sit at regular `n`-gon vertices with circumradius `radius`. Momenta
+are tangential. If `speed` is omitted, the speed is chosen from
+`energy_ratio = T0 / abs(U0)` using the initial Coulomb potential, optionally
+scaled by `kappas` in the same pair order as [`pair_indices`](@ref).
+
+Returns `(q, p, masses, charges)`.
+"""
+function polygon_initial_conditions(
+    n_in::Integer;
+    radius::Real,
+    mass::Real = 1.0,
+    charge_magnitude::Real = 1.0,
+    energy_ratio::Real = 0.5,
+    speed::Union{Nothing,Real} = nothing,
+    clockwise::Bool = false,
+    kappas::Union{Nothing,AbstractVector{<:Real}} = nothing,
+)
+    n = Int(n_in)
+    n >= 2 || throw(ArgumentError("n must be at least 2, got $n"))
+    radius_value = Float64(radius)
+    radius_value > 0 || throw(ArgumentError("radius must be positive, got $radius"))
+    mass_value = Float64(mass)
+    mass_value > 0 || throw(ArgumentError("mass must be positive, got $mass"))
+    Float64(energy_ratio) >= 0 ||
+        throw(ArgumentError("energy_ratio must be non-negative, got $energy_ratio"))
+
+    pair_count = n * (n - 1) ÷ 2
+    if !isnothing(kappas) && length(kappas) != pair_count
+        throw(ArgumentError("kappas must have length $pair_count for n=$n"))
+    end
+
+    masses_vec = fill(mass_value, n)
+    qmag = Float64(charge_magnitude)
+    charges_vec = [isodd(i) ? qmag : -qmag for i = 1:n]
+
+    q = Vector{Float64}(undef, 2n)
+    angles = [2pi * (i - 1) / n for i = 1:n]
+    @inbounds for i = 1:n
+        theta = angles[i]
+        q[2i-1] = radius_value * cos(theta)
+        q[2i] = radius_value * sin(theta)
+    end
+
+    potential = 0.0
+    pair_idx = 1
+    @inbounds for i = 1:n
+        qi = 2i - 1
+        for j = (i+1):n
+            qj = 2j - 1
+            dx = q[qi] - q[qj]
+            dy = q[qi+1] - q[qj+1]
+            r = sqrt(dx * dx + dy * dy)
+            kappa_ij = isnothing(kappas) ? 1.0 : Float64(kappas[pair_idx])
+            potential += kappa_ij * charges_vec[i] * charges_vec[j] / r
+            pair_idx += 1
+        end
+    end
+
+    speed_value =
+        isnothing(speed) ? sqrt(2 * Float64(energy_ratio) * abs(potential) / (n * mass_value)) :
+        Float64(speed)
+    speed_value >= 0 || throw(ArgumentError("speed must be non-negative, got $speed"))
+
+    sign = clockwise ? -1.0 : 1.0
+    p = Vector{Float64}(undef, 2n)
+    @inbounds for i = 1:n
+        theta = angles[i]
+        p[2i-1] = mass_value * speed_value * sign * (-sin(theta))
+        p[2i] = mass_value * speed_value * sign * cos(theta)
+    end
+
+    framed = center_of_mass_frame(q, p, masses_vec, 2)
+    return (q = framed.q, p = framed.p, masses = masses_vec, charges = charges_vec)
+end
+
+"""
+    rigid_rotation_initial_conditions(q, masses; angular_velocity,
+                                      dims=3, charges=zeros(n)) -> NamedTuple
+
+Return centre-of-mass initial conditions for a rigidly rotating configuration.
+
+The input `q` is flattened particle positions. In 3D, `angular_velocity` is a
+3-vector and momenta are `p_i = m_i * (omega x r_i)`. In 2D,
+`angular_velocity` may be a scalar z-angular velocity.
+
+Returns `(q, p, masses, charges)`.
+"""
+function rigid_rotation_initial_conditions(
+    q_in::AbstractVector{<:Real},
+    masses_in::AbstractVector{<:Real};
+    angular_velocity,
+    dims::Integer = 3,
+    charges::AbstractVector{<:Real} = zeros(Float64, length(masses_in)),
+)
+    dims_value = Int(dims)
+    dims_value in (2, 3) ||
+        throw(ArgumentError("rigid_rotation_initial_conditions supports dims=2 or dims=3"))
+
+    n = length(masses_in)
+    dof = n * dims_value
+    length(q_in) == dof ||
+        throw(ArgumentError("q must have length $dof for $n particles in $dims_value D"))
+    length(charges) == n || throw(ArgumentError("charges must have length $n"))
+
+    masses_vec = Vector{Float64}(masses_in)
+    charges_vec = Vector{Float64}(charges)
+    all(m -> m > 0, masses_vec) ||
+        throw(ArgumentError("all masses must be positive"))
+
+    q_centered = center_of_mass_frame(q_in, zeros(Float64, dof), masses_vec, dims_value).q
+    p = zeros(Float64, dof)
+
+    if dims_value == 2
+        omega =
+            angular_velocity isa Real ? Float64(angular_velocity) :
+            Float64(angular_velocity[end])
+        @inbounds for i = 1:n
+            offset = (i - 1) * 2
+            x = q_centered[offset+1]
+            y = q_centered[offset+2]
+            mi = masses_vec[i]
+            p[offset+1] = mi * (-omega * y)
+            p[offset+2] = mi * (omega * x)
+        end
+    else
+        length(angular_velocity) == 3 ||
+            throw(ArgumentError("3D angular_velocity must have length 3"))
+        wx = Float64(angular_velocity[1])
+        wy = Float64(angular_velocity[2])
+        wz = Float64(angular_velocity[3])
+        @inbounds for i = 1:n
+            offset = (i - 1) * 3
+            x = q_centered[offset+1]
+            y = q_centered[offset+2]
+            z = q_centered[offset+3]
+            mi = masses_vec[i]
+            p[offset+1] = mi * (wy * z - wz * y)
+            p[offset+2] = mi * (wz * x - wx * z)
+            p[offset+3] = mi * (wx * y - wy * x)
+        end
+    end
+
+    framed = center_of_mass_frame(q_centered, p, masses_vec, dims_value)
+    return (q = framed.q, p = framed.p, masses = masses_vec, charges = charges_vec)
+end

--- a/src/integrators/regularized.jl
+++ b/src/integrators/regularized.jl
@@ -1,7 +1,8 @@
 """
     RegularizedIntegrator{A}(base_alg::A; kwargs...)
+    RegularizedIntegrator(; kwargs...)
 
-Algorithm wrapper that activates Levi-Civita / KS regularization on top of a
+Algorithm wrapper that activates close-encounter regularization on top of a
 base Hamiltonian algorithm. `kwargs` mirror [`RegularizationOptions`](@ref)
 and are forwarded verbatim; `enabled` is set to `true` implicitly.
 
@@ -13,6 +14,7 @@ alg = RegularizedIntegrator(SymmetricProjectionIntegrator();
 sol = solve(prob, alg)
 ```
 
+The no-argument shorthand wraps `SymmetricProjectionIntegrator()`.
 The base algorithm's settings (e.g. `relaxation`) are preserved.
 """
 struct RegularizedIntegrator{A<:HamiltonianAlgorithm} <: HamiltonianAlgorithm
@@ -51,6 +53,10 @@ function RegularizedIntegrator(
     return RegularizedIntegrator(base_alg, options)
 end
 
+function RegularizedIntegrator(; kwargs...)
+    return RegularizedIntegrator(SymmetricProjectionIntegrator(); kwargs...)
+end
+
 """
     base_algorithm(alg::HamiltonianAlgorithm) -> HamiltonianAlgorithm
 
@@ -73,7 +79,7 @@ function _allocate_cache(prob::HamiltonianProblem, alg::RegularizedIntegrator)
     buffers = SymmetricProjectionBuffers(prob, alg.options)
     rb = buffers.regularization_buffers
     if rb.backend_fallback && alg.options.warn_on_fallback
-        @warn "RegularizationOptions(backend=:lifted_pair) is currently supported only for 2D; falling back to :adaptive_cartesian for $(prob.system.dims)D"
+        @warn "RegularizationOptions(backend=:lifted_pair) is not available for $(prob.system.dims)D; falling back to :adaptive_cartesian"
     end
     if !rb.backend_fallback && alg.options.warn_on_fallback && has_term(prob.system, :weber)
         @warn "RegularizedIntegrator handles close encounters by substepping/lifting the Coulomb singularity; Weber's velocity-dependent force is not analytically regularized" maxlog = 1

--- a/src/regularization.jl
+++ b/src/regularization.jl
@@ -364,6 +364,37 @@ end
     return abs(_ks_constraint(u, U))
 end
 
+@inline function _ks_project!(
+    q_rel::Vector{Float64},
+    p_rel::Vector{Float64},
+    u::Vector{Float64},
+    U::Vector{Float64},
+    J::Matrix{Float64},
+)
+    u1, u2, u3, u4 = u
+
+    q_rel[1] = u1 * u1 - u2 * u2 - u3 * u3 + u4 * u4
+    q_rel[2] = 2 * (u1 * u2 - u3 * u4)
+    q_rel[3] = 2 * (u1 * u3 + u2 * u4)
+
+    r = u1 * u1 + u2 * u2 + u3 * u3 + u4 * u4
+    if r <= eps(Float64)
+        return 0.0
+    end
+
+    _ks_jacobian!(J, u)
+    inv_4r = 0.25 / r
+    @inbounds for d = 1:3
+        value = 0.0
+        for k = 1:4
+            value += J[d, k] * U[k]
+        end
+        p_rel[d] = inv_4r * value
+    end
+
+    return r
+end
+
 @inline function _ks_lift!(rb::RegularizationBuffers)
     x1 = rb.rel_q[1]
     x2 = rb.rel_q[2]

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -325,13 +325,29 @@ end
         integrator.t = integrator.t_end
     end
 
-    idx = integrator.step_count + 1
-    @inbounds begin
-        integrator.t_history[idx] = integrator.t
-        integrator.q_history[idx] .= integrator.q
-        integrator.p_history[idx] .= integrator.p
+    _emit_stream_state!(integrator)
+
+    if _should_save_step(integrator)
+        integrator.save_count += 1
+        idx = integrator.save_count
+        @inbounds begin
+            integrator.t_history[idx] = integrator.t
+            integrator.q_history[idx] .= integrator.q
+            integrator.p_history[idx] .= integrator.p
+        end
     end
 
+    return nothing
+end
+
+@inline function _should_save_step(integrator::HamiltonianIntegrator)::Bool
+    step = integrator.step_count
+    return step == integrator.max_steps || step % integrator.save_stride == 0
+end
+
+@inline function _emit_stream_state!(integrator::HamiltonianIntegrator)
+    integrator.stream_sink === nothing && return nothing
+    integrator.stream_sink(integrator.t, integrator.q, integrator.p, integrator.step_count)
     return nothing
 end
 
@@ -476,6 +492,100 @@ end
 
         rb.rel_qdot[d] = dqi - dqj
         rb.rel_pdot[d] = mu * (dpi / mi - dpj / mj)
+    end
+
+    return nothing
+end
+
+@inline function _extract_pair_state!(
+    rb::RegularizationBuffers,
+    q_state::Vector{Float64},
+    p_state::Vector{Float64},
+    masses::AbstractVector{Float64},
+    dims::Int,
+    i::Int,
+    j::Int,
+)
+    mi = masses[i]
+    mj = masses[j]
+    M = mi + mj
+    mu = mi * mj / M
+
+    i0 = (i - 1) * dims
+    j0 = (j - 1) * dims
+
+    @inbounds for d = 1:dims
+        qi = q_state[i0+d]
+        qj = q_state[j0+d]
+        pi = p_state[i0+d]
+        pj = p_state[j0+d]
+
+        rb.pair_R[d] = (mi * qi + mj * qj) / M
+        rb.pair_P[d] = pi + pj
+        rb.rel_q[d] = qi - qj
+        rb.rel_p[d] = mu * (pi / mi - pj / mj)
+    end
+
+    return mi, mj, mu, M
+end
+
+@inline function _extract_pair_derivatives!(
+    rb::RegularizationBuffers,
+    dq_state::Vector{Float64},
+    dp_state::Vector{Float64},
+    dims::Int,
+    i::Int,
+    j::Int,
+    mi::Float64,
+    mj::Float64,
+    mu::Float64,
+    M::Float64,
+)
+    i0 = (i - 1) * dims
+    j0 = (j - 1) * dims
+
+    @inbounds for d = 1:dims
+        dqi = dq_state[i0+d]
+        dqj = dq_state[j0+d]
+        dpi = dp_state[i0+d]
+        dpj = dp_state[j0+d]
+
+        rb.pair_Rdot[d] = (mi * dqi + mj * dqj) / M
+        rb.pair_Pdot[d] = dpi + dpj
+        rb.rel_qdot[d] = dqi - dqj
+        rb.rel_pdot[d] = mu * (dpi / mi - dpj / mj)
+    end
+
+    return nothing
+end
+
+@inline function _write_pair_state!(
+    q_state::Vector{Float64},
+    p_state::Vector{Float64},
+    dims::Int,
+    i::Int,
+    j::Int,
+    mi::Float64,
+    mj::Float64,
+    M::Float64,
+    R::Vector{Float64},
+    P::Vector{Float64},
+    rel_q::Vector{Float64},
+    rel_p::Vector{Float64},
+)
+    i0 = (i - 1) * dims
+    j0 = (j - 1) * dims
+
+    αi = mj / M
+    αj = mi / M
+    βi = mi / M
+    βj = mj / M
+
+    @inbounds for d = 1:dims
+        q_state[i0+d] = R[d] + αi * rel_q[d]
+        q_state[j0+d] = R[d] - αj * rel_q[d]
+        p_state[i0+d] = βi * P[d] + rel_p[d]
+        p_state[j0+d] = βj * P[d] - rel_p[d]
     end
 
     return nothing
@@ -639,6 +749,75 @@ end
     return r_geom
 end
 
+@inline function _lift_1d!(
+    rb::RegularizationBuffers,
+    chart_sign::Float64,
+)
+    x = rb.rel_q[1]
+    p_rel = rb.rel_p[1]
+    r = abs(x)
+
+    if r <= eps(Float64)
+        rb.lc_u[1] = 0.0
+        rb.lc_U[1] = 0.0
+        return 0.0
+    end
+
+    sign_value = chart_sign
+    if sign_value == 0.0
+        sign_value = x < 0 ? -1.0 : 1.0
+    end
+    u = sqrt(r)
+    rb.lc_u[1] = u
+    rb.lc_U[1] = 2 * sign_value * u * p_rel
+    return r
+end
+
+@inline function _project_1d!(
+    q_rel::Vector{Float64},
+    p_rel::Vector{Float64},
+    u::Vector{Float64},
+    U::Vector{Float64},
+    chart_sign::Float64,
+)
+    u1 = u[1]
+    q_rel[1] = chart_sign * u1 * u1
+
+    if abs(u1) <= eps(Float64)
+        return 0.0
+    end
+
+    p_rel[1] = U[1] / (2 * chart_sign * u1)
+    return abs(q_rel[1])
+end
+
+@inline function _compute_1d_tau_derivatives!(
+    du_tau::Vector{Float64},
+    dU_tau::Vector{Float64},
+    u::Vector{Float64},
+    p_rel::Vector{Float64},
+    qdot_rel::Vector{Float64},
+    pdot_rel::Vector{Float64},
+    chart_sign::Float64,
+    g_scale::Float64,
+    g_floor::Float64,
+)
+    u1 = u[1]
+    r_geom = max(u1 * u1, g_floor)
+
+    if abs(u1) <= eps(Float64)
+        du_dt = 0.0
+    else
+        du_dt = qdot_rel[1] / (2 * chart_sign * u1)
+    end
+    dU_dt = 2 * chart_sign * (du_dt * p_rel[1] + u1 * pdot_rel[1])
+
+    du_tau[1] = g_scale * du_dt
+    dU_tau[1] = g_scale * dU_dt
+
+    return r_geom
+end
+
 @inline function _lifted_pair_substep_2d!(
     q::Vector{Float64},
     p::Vector{Float64},
@@ -747,6 +926,321 @@ end
     return nothing
 end
 
+@inline function _lifted_pair_substep_1d!(
+    q::Vector{Float64},
+    p::Vector{Float64},
+    t::Float64,
+    dt_sub::Float64,
+    prob::HamiltonianProblem,
+    rb::RegularizationBuffers,
+    i::Int,
+    j::Int,
+)
+    system = prob.system
+    ms = masses(prob)
+    g_floor = rb.options.g_floor
+
+    prev_u = rb.lc_u[1]
+
+    system.dq_dt_compiled(rb.dq_pair, q, p, t, rb.params_pair, rb.kappas_pair)
+    system.dp_dt_compiled(rb.dp_pair, q, p, t, rb.params_pair, rb.kappas_pair)
+
+    mi, mj, mu, M = _extract_pair_state!(rb, q, p, ms, 1, i, j)
+    _extract_pair_derivatives!(rb, rb.dq_pair, rb.dp_pair, 1, i, j, mi, mj, mu, M)
+
+    chart_sign = rb.rel_q[1] < 0 ? -1.0 : 1.0
+    _lift_1d!(rb, chart_sign)
+    if prev_u != 0.0 && rb.lc_u[1] * prev_u < 0
+        rb.lc_u[1] = -rb.lc_u[1]
+        rb.lc_U[1] = -rb.lc_U[1]
+    end
+
+    r_eff = max(rb.lc_u[1] * rb.lc_u[1], g_floor)
+    _compute_1d_tau_derivatives!(
+        rb.lc_du_tau,
+        rb.lc_dU_tau,
+        rb.lc_u,
+        rb.rel_p,
+        rb.rel_qdot,
+        rb.rel_pdot,
+        chart_sign,
+        r_eff,
+        g_floor,
+    )
+
+    dτ = dt_sub / r_eff
+
+    @inbounds begin
+        rb.lc_u_mid[1] = rb.lc_u[1] + 0.5 * dτ * rb.lc_du_tau[1]
+        rb.lc_U_mid[1] = rb.lc_U[1] + 0.5 * dτ * rb.lc_dU_tau[1]
+        rb.pair_R_mid[1] = rb.pair_R[1] + 0.5 * dt_sub * rb.pair_Rdot[1]
+        rb.pair_P_mid[1] = rb.pair_P[1] + 0.5 * dt_sub * rb.pair_Pdot[1]
+    end
+
+    _project_1d!(rb.temp_rel_q, rb.temp_rel_p, rb.lc_u_mid, rb.lc_U_mid, chart_sign)
+
+    copyto!(rb.q_mid, q)
+    copyto!(rb.p_mid, p)
+    _write_pair_state!(
+        rb.q_mid,
+        rb.p_mid,
+        1,
+        i,
+        j,
+        mi,
+        mj,
+        M,
+        rb.pair_R_mid,
+        rb.pair_P_mid,
+        rb.temp_rel_q,
+        rb.temp_rel_p,
+    )
+
+    t_mid = t + dt_sub * 0.5
+    system.dq_dt_compiled(rb.dq_pair, rb.q_mid, rb.p_mid, t_mid, rb.params_pair, rb.kappas_pair)
+    system.dp_dt_compiled(rb.dp_pair, rb.q_mid, rb.p_mid, t_mid, rb.params_pair, rb.kappas_pair)
+    _extract_pair_derivatives!(rb, rb.dq_pair, rb.dp_pair, 1, i, j, mi, mj, mu, M)
+
+    _compute_1d_tau_derivatives!(
+        rb.lc_du_tau_mid,
+        rb.lc_dU_tau_mid,
+        rb.lc_u_mid,
+        rb.temp_rel_p,
+        rb.rel_qdot,
+        rb.rel_pdot,
+        chart_sign,
+        r_eff,
+        g_floor,
+    )
+
+    @inbounds begin
+        rb.lc_u[1] = rb.lc_u[1] + dτ * rb.lc_du_tau_mid[1]
+        rb.lc_U[1] = rb.lc_U[1] + dτ * rb.lc_dU_tau_mid[1]
+        rb.pair_R[1] = rb.pair_R[1] + dt_sub * rb.pair_Rdot[1]
+        rb.pair_P[1] = rb.pair_P[1] + dt_sub * rb.pair_Pdot[1]
+    end
+
+    _project_1d!(rb.rel_q, rb.rel_p, rb.lc_u, rb.lc_U, chart_sign)
+    _write_pair_state!(q, p, 1, i, j, mi, mj, M, rb.pair_R, rb.pair_P, rb.rel_q, rb.rel_p)
+
+    return nothing
+end
+
+@inline function _compute_ks_tau_derivatives!(
+    du_tau::Vector{Float64},
+    dU_tau::Vector{Float64},
+    u::Vector{Float64},
+    p_rel::Vector{Float64},
+    qdot_rel::Vector{Float64},
+    pdot_rel::Vector{Float64},
+    J::Matrix{Float64},
+    g_scale::Float64,
+    g_floor::Float64,
+)
+    r = u[1] * u[1] + u[2] * u[2] + u[3] * u[3] + u[4] * u[4]
+    r_geom = max(r, g_floor)
+
+    _ks_jacobian!(J, u)
+    inv_4r = 0.25 / r_geom
+    @inbounds for k = 1:4
+        du_dt = 0.0
+        for d = 1:3
+            du_dt += J[d, k] * qdot_rel[d]
+        end
+        du_dt *= inv_4r
+        du_tau[k] = g_scale * du_dt
+    end
+
+    du1 = du_tau[1] / g_scale
+    du2 = du_tau[2] / g_scale
+    du3 = du_tau[3] / g_scale
+    du4 = du_tau[4] / g_scale
+    p1, p2, p3 = p_rel[1], p_rel[2], p_rel[3]
+
+    @inbounds begin
+        dU_dt1 =
+            J[1, 1] * pdot_rel[1] + J[2, 1] * pdot_rel[2] + J[3, 1] * pdot_rel[3] +
+            2 * (du1 * p1 + du2 * p2 + du3 * p3)
+        dU_dt2 =
+            J[1, 2] * pdot_rel[1] + J[2, 2] * pdot_rel[2] + J[3, 2] * pdot_rel[3] +
+            2 * (-du2 * p1 + du1 * p2 + du4 * p3)
+        dU_dt3 =
+            J[1, 3] * pdot_rel[1] + J[2, 3] * pdot_rel[2] + J[3, 3] * pdot_rel[3] +
+            2 * (-du3 * p1 - du4 * p2 + du1 * p3)
+        dU_dt4 =
+            J[1, 4] * pdot_rel[1] + J[2, 4] * pdot_rel[2] + J[3, 4] * pdot_rel[3] +
+            2 * (du4 * p1 - du3 * p2 + du2 * p3)
+
+        dU_tau[1] = g_scale * dU_dt1
+        dU_tau[2] = g_scale * dU_dt2
+        dU_tau[3] = g_scale * dU_dt3
+        dU_tau[4] = g_scale * dU_dt4
+    end
+
+    return r_geom
+end
+
+@inline function _project_ks_constraint_tracked!(
+    diagnostics::RegularizationDiagnostics,
+    U::Vector{Float64},
+    u::Vector{Float64},
+    n::Vector{Float64},
+    tolerance::Float64,
+)::Float64
+    before = abs(_ks_constraint(u, U))
+    after = _ks_project_constraint!(U, u, n)
+    diagnostics.ks_constraint_projection_count += 1
+    diagnostics.ks_constraint_iteration_count += 1
+    return after <= tolerance ? 0.0 : max(before, after)
+end
+
+@inline function _lifted_pair_substep_3d!(
+    q::Vector{Float64},
+    p::Vector{Float64},
+    t::Float64,
+    dt_sub::Float64,
+    prob::HamiltonianProblem,
+    rb::RegularizationBuffers,
+    diagnostics::RegularizationDiagnostics,
+    i::Int,
+    j::Int,
+)
+    system = prob.system
+    ms = masses(prob)
+    reg = rb.options
+    g_floor = reg.g_floor
+
+    prev_u1 = rb.ks_u[1]
+    prev_u2 = rb.ks_u[2]
+    prev_u3 = rb.ks_u[3]
+    prev_u4 = rb.ks_u[4]
+    prev_norm2 = prev_u1^2 + prev_u2^2 + prev_u3^2 + prev_u4^2
+
+    system.dq_dt_compiled(rb.dq_pair, q, p, t, rb.params_pair, rb.kappas_pair)
+    system.dp_dt_compiled(rb.dp_pair, q, p, t, rb.params_pair, rb.kappas_pair)
+
+    mi, mj, mu, M = _extract_pair_state!(rb, q, p, ms, 3, i, j)
+    _extract_pair_derivatives!(rb, rb.dq_pair, rb.dp_pair, 3, i, j, mi, mj, mu, M)
+
+    _ks_lift!(rb)
+    if prev_norm2 > 0
+        dot_u =
+            rb.ks_u[1] * prev_u1 + rb.ks_u[2] * prev_u2 + rb.ks_u[3] * prev_u3 +
+            rb.ks_u[4] * prev_u4
+        if dot_u < 0
+            @inbounds for k = 1:4
+                rb.ks_u[k] = -rb.ks_u[k]
+                rb.ks_U[k] = -rb.ks_U[k]
+            end
+        end
+    end
+
+    max_constraint = _project_ks_constraint_tracked!(
+        diagnostics,
+        rb.ks_U,
+        rb.ks_u,
+        rb.ks_n,
+        reg.constraint_tolerance,
+    )
+
+    r_eff = max(
+        rb.ks_u[1]^2 + rb.ks_u[2]^2 + rb.ks_u[3]^2 + rb.ks_u[4]^2,
+        g_floor,
+    )
+    _compute_ks_tau_derivatives!(
+        rb.ks_du_tau,
+        rb.ks_dU_tau,
+        rb.ks_u,
+        rb.rel_p,
+        rb.rel_qdot,
+        rb.rel_pdot,
+        rb.ks_J,
+        r_eff,
+        g_floor,
+    )
+
+    dτ = dt_sub / r_eff
+
+    @inbounds for k = 1:4
+        rb.ks_u_mid[k] = rb.ks_u[k] + 0.5 * dτ * rb.ks_du_tau[k]
+        rb.ks_U_mid[k] = rb.ks_U[k] + 0.5 * dτ * rb.ks_dU_tau[k]
+    end
+    @inbounds for d = 1:3
+        rb.pair_R_mid[d] = rb.pair_R[d] + 0.5 * dt_sub * rb.pair_Rdot[d]
+        rb.pair_P_mid[d] = rb.pair_P[d] + 0.5 * dt_sub * rb.pair_Pdot[d]
+    end
+
+    max_constraint = max(
+        max_constraint,
+        _project_ks_constraint_tracked!(
+            diagnostics,
+            rb.ks_U_mid,
+            rb.ks_u_mid,
+            rb.ks_n,
+            reg.constraint_tolerance,
+        ),
+    )
+    _ks_project!(rb.temp_rel_q, rb.temp_rel_p, rb.ks_u_mid, rb.ks_U_mid, rb.ks_J)
+
+    copyto!(rb.q_mid, q)
+    copyto!(rb.p_mid, p)
+    _write_pair_state!(
+        rb.q_mid,
+        rb.p_mid,
+        3,
+        i,
+        j,
+        mi,
+        mj,
+        M,
+        rb.pair_R_mid,
+        rb.pair_P_mid,
+        rb.temp_rel_q,
+        rb.temp_rel_p,
+    )
+
+    t_mid = t + dt_sub * 0.5
+    system.dq_dt_compiled(rb.dq_pair, rb.q_mid, rb.p_mid, t_mid, rb.params_pair, rb.kappas_pair)
+    system.dp_dt_compiled(rb.dp_pair, rb.q_mid, rb.p_mid, t_mid, rb.params_pair, rb.kappas_pair)
+    _extract_pair_derivatives!(rb, rb.dq_pair, rb.dp_pair, 3, i, j, mi, mj, mu, M)
+
+    _compute_ks_tau_derivatives!(
+        rb.ks_du_tau_mid,
+        rb.ks_dU_tau_mid,
+        rb.ks_u_mid,
+        rb.temp_rel_p,
+        rb.rel_qdot,
+        rb.rel_pdot,
+        rb.ks_J,
+        r_eff,
+        g_floor,
+    )
+
+    @inbounds for k = 1:4
+        rb.ks_u[k] = rb.ks_u[k] + dτ * rb.ks_du_tau_mid[k]
+        rb.ks_U[k] = rb.ks_U[k] + dτ * rb.ks_dU_tau_mid[k]
+    end
+    @inbounds for d = 1:3
+        rb.pair_R[d] = rb.pair_R[d] + dt_sub * rb.pair_Rdot[d]
+        rb.pair_P[d] = rb.pair_P[d] + dt_sub * rb.pair_Pdot[d]
+    end
+
+    max_constraint = max(
+        max_constraint,
+        _project_ks_constraint_tracked!(
+            diagnostics,
+            rb.ks_U,
+            rb.ks_u,
+            rb.ks_n,
+            reg.constraint_tolerance,
+        ),
+    )
+    _ks_project!(rb.rel_q, rb.rel_p, rb.ks_u, rb.ks_U, rb.ks_J)
+    _write_pair_state!(q, p, 3, i, j, mi, mj, M, rb.pair_R, rb.pair_P, rb.rel_q, rb.rel_p)
+
+    return max_constraint
+end
+
 @inline function _step_unregularized!(integrator::HamiltonianIntegrator, dt_step::Float64)
     _projected_cartesian_step!(
         integrator.q,
@@ -824,13 +1318,16 @@ end
             # KS lift + one-pass constraint projection (diagnostic only).
             # The Cartesian substep that follows does not maintain the KS bilinear
             # constraint; c_err is tracked for diagnostics but not iterated to
-            # convergence. True 3D lifted-KS stepping is deferred per design.
+            # convergence. Use :lifted_pair for the full lifted KS pair path.
             # See RegularizedIntegrationDesign.md §"KS Constraint Handling".
             _ks_lift!(rb)
-            c_err = _ks_project_constraint!(rb.ks_U, rb.ks_u, rb.ks_n)
-            if c_err <= constraint_tolerance
-                c_err = 0.0
-            end
+            c_err = _project_ks_constraint_tracked!(
+                integrator.diagnostics,
+                rb.ks_U,
+                rb.ks_u,
+                rb.ks_n,
+                constraint_tolerance,
+            )
             if c_err > max_constraint
                 max_constraint = c_err
             end
@@ -845,6 +1342,7 @@ end
             base_algorithm(integrator.alg),
             integrator.buffers,
         )
+        _apply_regularized_substep_bounces!(integrator)
         t_sub += dt_sub
     end
 
@@ -861,13 +1359,14 @@ end
     return nothing
 end
 
-@inline function _step_regularized_pair_lifted_2d!(
+@inline function _step_regularized_pair_lifted!(
     integrator::HamiltonianIntegrator,
     dt_step::Float64,
     min_distance::Float64,
 )
     prob = integrator.prob
     rb = integrator.buffers.regularization_buffers
+    dims = rb.dims
 
     i = rb.active_anchor_i
     j = rb.active_anchor_j
@@ -885,9 +1384,10 @@ end
     t_remaining = dt_step
     substeps = 0
     t_sub = integrator.t
+    max_constraint = 0.0
 
     @inbounds while t_remaining > 1e-14 && substeps < max_sub
-        r_current = max(_current_pair_r_2d(integrator.q, i, j), g_floor)
+        r_current = max(_current_pair_r(integrator.q, dims, i, j), g_floor)
 
         # Physical substep proportional to current r (bounded fictitious step).
         dt_sub = min(r_current * dtau_target, t_remaining)
@@ -897,16 +1397,44 @@ end
         dt_half = 0.5 * dt_sub
 
         _external_half_step_midpoint!(integrator.q, integrator.p, t_sub, dt_half, prob, rb)
-        _lifted_pair_substep_2d!(
-            integrator.q,
-            integrator.p,
-            t_sub + dt_half,
-            dt_sub,
-            prob,
-            rb,
-            i,
-            j,
-        )
+        if dims == 1
+            _lifted_pair_substep_1d!(
+                integrator.q,
+                integrator.p,
+                t_sub + dt_half,
+                dt_sub,
+                prob,
+                rb,
+                i,
+                j,
+            )
+        elseif dims == 2
+            _lifted_pair_substep_2d!(
+                integrator.q,
+                integrator.p,
+                t_sub + dt_half,
+                dt_sub,
+                prob,
+                rb,
+                i,
+                j,
+            )
+        else
+            max_constraint = max(
+                max_constraint,
+                _lifted_pair_substep_3d!(
+                    integrator.q,
+                    integrator.p,
+                    t_sub + dt_half,
+                    dt_sub,
+                    prob,
+                    rb,
+                    integrator.diagnostics,
+                    i,
+                    j,
+                ),
+            )
+        end
         _external_half_step_midpoint!(
             integrator.q,
             integrator.p,
@@ -915,6 +1443,7 @@ end
             prob,
             rb,
         )
+        _apply_regularized_substep_bounces!(integrator)
 
         t_remaining -= dt_sub
         t_sub += dt_sub
@@ -925,16 +1454,44 @@ end
     if t_remaining > 1e-14
         dt_half = 0.5 * t_remaining
         _external_half_step_midpoint!(integrator.q, integrator.p, t_sub, dt_half, prob, rb)
-        _lifted_pair_substep_2d!(
-            integrator.q,
-            integrator.p,
-            t_sub + dt_half,
-            t_remaining,
-            prob,
-            rb,
-            i,
-            j,
-        )
+        if dims == 1
+            _lifted_pair_substep_1d!(
+                integrator.q,
+                integrator.p,
+                t_sub + dt_half,
+                t_remaining,
+                prob,
+                rb,
+                i,
+                j,
+            )
+        elseif dims == 2
+            _lifted_pair_substep_2d!(
+                integrator.q,
+                integrator.p,
+                t_sub + dt_half,
+                t_remaining,
+                prob,
+                rb,
+                i,
+                j,
+            )
+        else
+            max_constraint = max(
+                max_constraint,
+                _lifted_pair_substep_3d!(
+                    integrator.q,
+                    integrator.p,
+                    t_sub + dt_half,
+                    t_remaining,
+                    prob,
+                    rb,
+                    integrator.diagnostics,
+                    i,
+                    j,
+                ),
+            )
+        end
         _external_half_step_midpoint!(
             integrator.q,
             integrator.p,
@@ -943,6 +1500,7 @@ end
             prob,
             rb,
         )
+        _apply_regularized_substep_bounces!(integrator)
         substeps += 1
     end
 
@@ -952,7 +1510,7 @@ end
         REG_MODE_PAIR,
         substeps,
         min_distance,
-        0.0,
+        max_constraint,
         REG_BACKEND_LIFTED,
         rb.backend_fallback,
     )
@@ -990,10 +1548,13 @@ end
                 j = rb.chain_order[idx+1]
                 _extract_pair_relative_state!(rb, integrator.q, integrator.p, ms, i, j)
                 _ks_lift!(rb)
-                c_err = _ks_project_constraint!(rb.ks_U, rb.ks_u, rb.ks_n)
-                if c_err <= constraint_tolerance
-                    c_err = 0.0
-                end
+                c_err = _project_ks_constraint_tracked!(
+                    integrator.diagnostics,
+                    rb.ks_U,
+                    rb.ks_u,
+                    rb.ks_n,
+                    constraint_tolerance,
+                )
                 if c_err > max_constraint
                     max_constraint = c_err
                 end
@@ -1009,6 +1570,7 @@ end
             base_algorithm(integrator.alg),
             integrator.buffers,
         )
+        _apply_regularized_substep_bounces!(integrator)
         t_sub += dt_sub
     end
 
@@ -1050,8 +1612,8 @@ end
 
     if mode == REG_MODE_CHAIN
         _step_regularized_chain!(integrator, dt_step, min_distance)
-    elseif rb.effective_backend == REG_BACKEND_LIFTED && rb.dims == 2
-        _step_regularized_pair_lifted_2d!(integrator, dt_step, min_distance)
+    elseif rb.effective_backend == REG_BACKEND_LIFTED && rb.dims in (1, 2, 3)
+        _step_regularized_pair_lifted!(integrator, dt_step, min_distance)
     else
         _step_regularized_pair_adaptive!(integrator, dt_step, min_distance)
     end
@@ -1078,6 +1640,8 @@ end
     out.total_substeps = diagnostics.total_substeps
     out.max_substeps_used = diagnostics.max_substeps_used
     out.max_constraint_violation = diagnostics.max_constraint_violation
+    out.ks_constraint_projection_count = diagnostics.ks_constraint_projection_count
+    out.ks_constraint_iteration_count = diagnostics.ks_constraint_iteration_count
     out.min_encounter_distance = diagnostics.min_encounter_distance
 
     if n_steps > 0
@@ -1105,20 +1669,49 @@ end
 # `_allocate_cache(::HamiltonianProblem, ::RegularizedIntegrator)` lives in
 # integrators/regularized.jl because the type is defined there.
 
+function _resolve_save_stride(save_stride::Integer, save_every)
+    if save_every !== nothing
+        save_stride != 1 &&
+            throw(ArgumentError("pass only one of save_stride or save_every"))
+        save_stride = save_every
+    end
+    stride = Int(save_stride)
+    stride > 0 || throw(ArgumentError("save_stride must be positive, got $stride"))
+    return stride
+end
+
+@inline function _saved_history_length(n_steps::Int, save_stride::Int)::Int
+    n_steps == 0 && return 1
+    saved_completed_steps = n_steps ÷ save_stride
+    if n_steps % save_stride != 0
+        saved_completed_steps += 1
+    end
+    return saved_completed_steps + 1
+end
+
 """
     init(prob::HamiltonianProblem,
          alg::HamiltonianAlgorithm = SymmetricProjectionIntegrator();
-         callbacks = ()) -> HamiltonianIntegrator
+         callbacks = (),
+         save_stride = 1,
+         save_every = nothing,
+         stream_sink = nothing) -> HamiltonianIntegrator
 
 Initialise a step-by-step integrator without running any steps.
 
-Pre-allocates all workspace buffers and history arrays sized to hold the full
-trajectory. Use the returned integrator with `step!` for fine-grained control,
+Pre-allocates all workspace buffers and history arrays sized according to the
+save policy. Use the returned integrator with `step!` for fine-grained control,
 or pass it directly to `solve!`.
 
 # Keyword arguments
 - `callbacks`: a single [`HamiltonianCallback`](@ref) or an iterable of them.
   Invoked pre-/post-step around each macro-step.
+- `save_stride=1`: Store every `save_stride`-th macro-step plus the initial and
+  final states. The default stores every step.
+- `save_every=nothing`: Alias for `save_stride`; pass only one of the two.
+- `stream_sink=nothing`: Optional callable invoked as `(t, q, p, step)` for the
+  initial state and after every macro-step. The sink must copy `q`/`p` if it
+  retains them.
 
 If `alg` is a `RegularizedIntegrator` with `collision_bounce_radius > 0` and
 no `CollisionBounce` is present in `callbacks`, a matching one is synthesised
@@ -1131,16 +1724,21 @@ function CommonSolve.init(
     prob::HamiltonianProblem,
     alg::HamiltonianAlgorithm = SymmetricProjectionIntegrator();
     callbacks = (),
+    save_stride::Integer = 1,
+    save_every = nothing,
+    stream_sink = nothing,
 )
     degrees_of_freedom = prob.system.degrees_of_freedom
 
     buffers = _allocate_cache(prob, alg)
     cb_tuple = _resolve_callbacks(prob, alg, callbacks)
+    stride = _resolve_save_stride(save_stride, save_every)
 
     n_steps = Int(ceil((prob.tspan[2] - prob.tspan[1]) / prob.dt))
-    t_history = Vector{Float64}(undef, n_steps + 1)
-    q_history = [Vector{Float64}(undef, degrees_of_freedom) for _ = 1:(n_steps+1)]
-    p_history = [Vector{Float64}(undef, degrees_of_freedom) for _ = 1:(n_steps+1)]
+    n_saved = _saved_history_length(n_steps, stride)
+    t_history = Vector{Float64}(undef, n_saved)
+    q_history = [Vector{Float64}(undef, degrees_of_freedom) for _ = 1:n_saved]
+    p_history = [Vector{Float64}(undef, degrees_of_freedom) for _ = 1:n_saved]
 
     t_history[1] = prob.tspan[1]
     q_history[1] .= prob.q_initial
@@ -1156,7 +1754,7 @@ function CommonSolve.init(
         used_backend,
     )
 
-    HamiltonianIntegrator(
+    integrator = HamiltonianIntegrator(
         prob,
         alg,
         prob.tspan[1],
@@ -1164,13 +1762,19 @@ function CommonSolve.init(
         copy(prob.q_initial),
         copy(prob.p_initial),
         0,
+        n_steps,
         buffers,
         cb_tuple,
         diagnostics,
         t_history,
         q_history,
         p_history,
+        stride,
+        1,
+        stream_sink,
     )
+    _emit_stream_state!(integrator)
+    return integrator
 end
 
 # Merge user-supplied callbacks with algorithm-synthesised ones. Base version
@@ -1202,6 +1806,32 @@ end
     return nothing
 end
 
+@inline _callback_collision_radius(::Tuple{}) = 0.0
+@inline function _callback_collision_radius(cbs::Tuple)
+    cb = first(cbs)
+    current = cb isa CollisionBounce ? cb.radius : 0.0
+    return max(current, _callback_collision_radius(Base.tail(cbs)))
+end
+
+@inline function _regularized_bounce_radius(integrator::HamiltonianIntegrator)
+    rb = integrator.buffers.regularization_buffers
+    return max(rb.options.collision_bounce_radius, _callback_collision_radius(integrator.callbacks))
+end
+
+@inline function _apply_regularized_substep_bounces!(integrator::HamiltonianIntegrator)
+    bounce_r = _regularized_bounce_radius(integrator)
+    bounce_r > 0 || return nothing
+    prob = integrator.prob
+    _apply_collision_bounces!(
+        integrator.q,
+        masses(prob),
+        prob.system.dims,
+        prob.system.n_particles,
+        bounce_r,
+    )
+    return nothing
+end
+
 """
     step!(integrator::HamiltonianIntegrator) -> Bool
 
@@ -1216,7 +1846,7 @@ to land exactly on `prob.tspan[2]`.
 - `true` if more steps remain, `false` when integration is complete.
 """
 function CommonSolve.step!(integrator::HamiltonianIntegrator)
-    max_steps = length(integrator.t_history) - 1
+    max_steps = integrator.max_steps
 
     if integrator.step_count >= max_steps ||
        integrator.t >= integrator.t_end - eps(integrator.t_end)
@@ -1264,7 +1894,7 @@ function CommonSolve.solve!(integrator::HamiltonianIntegrator)
         end
     end
 
-    n = integrator.step_count + 1
+    n = integrator.save_count
     diagnostics = _clone_diagnostics(integrator.diagnostics, integrator.step_count)
 
     HamiltonianSolution(
@@ -1278,7 +1908,12 @@ function CommonSolve.solve!(integrator::HamiltonianIntegrator)
 end
 
 """
-    solve(prob::HamiltonianProblem, alg::HamiltonianAlgorithm = SymmetricProjectionIntegrator()) -> HamiltonianSolution
+    solve(prob::HamiltonianProblem,
+          alg::HamiltonianAlgorithm = SymmetricProjectionIntegrator();
+          callbacks = (),
+          save_stride = 1,
+          save_every = nothing,
+          stream_sink = nothing) -> HamiltonianSolution
 
 Initialise and run the integrator in a single call.
 
@@ -1291,7 +1926,17 @@ function CommonSolve.solve(
     prob::HamiltonianProblem,
     alg::HamiltonianAlgorithm = SymmetricProjectionIntegrator();
     callbacks = (),
+    save_stride::Integer = 1,
+    save_every = nothing,
+    stream_sink = nothing,
 )
-    integrator = CommonSolve.init(prob, alg; callbacks = callbacks)
+    integrator = CommonSolve.init(
+        prob,
+        alg;
+        callbacks = callbacks,
+        save_stride = save_stride,
+        save_every = save_every,
+        stream_sink = stream_sink,
+    )
     CommonSolve.solve!(integrator)
 end

--- a/src/statistics/energy.jl
+++ b/src/statistics/energy.jl
@@ -405,3 +405,88 @@ function Base.show(io::IO, ::MIME"text/plain", data::EnergyData)
         "  Hamiltonian validation: max error = $(maximum(data.hamiltonian_validation_error))",
     )
 end
+
+function _summary_min_pair_distance(sol::HamiltonianSolution, stride::Int)
+    n = n_particles(sol.prob)
+    d = dims(sol.prob)
+    n < 2 && return Inf
+
+    min_r = Inf
+    @inbounds for sol_idx in 1:stride:length(sol.t)
+        q = sol.q[sol_idx]
+        for i = 1:n
+            i0 = (i - 1) * d
+            for j = (i+1):n
+                j0 = (j - 1) * d
+                r2 = 0.0
+                for k = 1:d
+                    dx = q[i0+k] - q[j0+k]
+                    r2 += dx * dx
+                end
+                min_r = min(min_r, sqrt(r2))
+            end
+        end
+    end
+    return min_r
+end
+
+function _summary_angular_drift(momentum)
+    if isnothing(momentum.angular_momentum_magnitude)
+        return (max = nothing, relative_max = nothing)
+    end
+
+    initial = momentum.angular_momentum_magnitude[1]
+    max_drift = 0.0
+    @inbounds for value in momentum.angular_momentum_magnitude
+        max_drift = max(max_drift, abs(value - initial))
+    end
+    relative =
+        abs(initial) <= 100 * eps(Float64) ? NaN : max_drift / abs(initial)
+    return (max = max_drift, relative_max = relative)
+end
+
+"""
+    conservation_summary(sol; stride=1) -> NamedTuple
+
+Return a compact conservation summary for notebooks, smoke tests, and
+regression checks.
+
+The result contains energy error statistics, maximum linear and angular
+momentum drift, the minimum sampled pair distance, and the solution's
+regularization diagnostics.
+"""
+function conservation_summary(sol::HamiltonianSolution; stride::Int = 1)
+    stride > 0 || throw(ArgumentError("stride must be positive, got $stride"))
+
+    energy = compute_energy_timeseries(sol; stride = stride)
+    momentum = compute_momentum_timeseries(sol; stride = stride)
+
+    linear_initial = momentum.linear_momentum_magnitude[1]
+    linear_drift_max = 0.0
+    @inbounds for value in momentum.linear_momentum_magnitude
+        linear_drift_max = max(linear_drift_max, abs(value - linear_initial))
+    end
+    linear_relative =
+        abs(linear_initial) <= 100 * eps(Float64) ? NaN :
+        linear_drift_max / abs(linear_initial)
+
+    angular = _summary_angular_drift(momentum)
+    validation_max = maximum(energy.hamiltonian_validation_error)
+
+    return (
+        n_points = length(energy.t),
+        energy = (
+            local_error_max = energy.statistics.local_error_max,
+            global_error_percent_max = energy.statistics.global_error_percent_max,
+            hamiltonian_validation_max = validation_max,
+        ),
+        momentum = (
+            linear_drift_max = linear_drift_max,
+            linear_relative_drift_max = linear_relative,
+            angular_drift_max = angular.max,
+            angular_relative_drift_max = angular.relative_max,
+        ),
+        min_pair_distance = _summary_min_pair_distance(sol, stride),
+        regularization = sol.regularization,
+    )
+end

--- a/src/statistics/trajectories.jl
+++ b/src/statistics/trajectories.jl
@@ -22,14 +22,15 @@ struct TrajectoryData
 end
 
 """
+    compute_trajectory_data(sol; stride=1) -> TrajectoryData
     compute_trajectory_data(sol, n_particles, dims; stride=1) -> TrajectoryData
 
 Extract per-particle position trajectories from a `HamiltonianSolution`.
 
 # Arguments
 - `sol::HamiltonianSolution`: Completed simulation result.
-- `n_particles::Int`: Number of particles encoded in `sol`.
-- `dims::Int`: Spatial dimension (must match `dims(sol.prob)`).
+- `n_particles::Int`: Optional explicit number of particles encoded in `sol`.
+- `dims::Int`: Optional explicit spatial dimension (must match `dims(sol.prob)`).
 
 # Keywords
 - `stride=1`: Downsample factor; every `stride`-th timestep is included.
@@ -94,4 +95,11 @@ function compute_trajectory_data(
         n_particles,
         dims,
     )
+end
+
+function compute_trajectory_data(
+    sol::HamiltonianSolution;
+    stride::Int = 1,
+)::TrajectoryData
+    return compute_trajectory_data(sol, n_particles(sol.prob), dims(sol.prob); stride = stride)
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -106,8 +106,9 @@ end
 Configuration for close-encounter regularization.
 
 When two particles approach within `r_on`, the integrator switches from
-Cartesian coordinates to a regularized representation (Levi-Civita/KS or
-adaptive Cartesian substeps) and back once the separation exceeds `r_off`.
+Cartesian coordinates to a regularized representation (1D square-root,
+2D Levi-Civita, 3D KS, or adaptive Cartesian substeps) and back once the
+separation exceeds `r_off`.
 
 # Keywords
 - `enabled=false`: Enable regularization globally.
@@ -121,9 +122,9 @@ adaptive Cartesian substeps) and back once the separation exceeds `r_off`.
 - `constraint_tolerance=1e-12`: Convergence threshold for the projection constraint.
 - `g_floor=1e-12`: Minimum regularization scale to prevent division by zero.
 - `chain_enabled=true`: Allow chain regularization for multi-particle close encounters.
-- `backend=:lifted_pair`: Regularization backend. `:lifted_pair` uses
-  Levi-Civita/KS (2D only; auto-falls back to `:adaptive_cartesian` for 3D).
-  `:adaptive_cartesian` works for all dimensions.
+- `backend=:lifted_pair`: Regularization backend. `:lifted_pair` uses lifted
+  square-root (1D), Levi-Civita (2D), or KS (3D) pair charts.
+  `:adaptive_cartesian` works for all dimensions and for chain encounters.
 - `warn_on_fallback=true`: Emit a warning when the backend is automatically changed.
 - `collision_bounce_radius=0.0`: Reflect pairs that come closer than this distance
   before each macro-step (0.0 = disabled). Intended for head-on (ℓ=0) collisions.
@@ -210,13 +211,16 @@ of the outer `SymmetricProjectionIntegrator`.
 - `active_steps::Int`: Steps taken while any regularization was active.
 - `pair_steps::Int`: Steps handled by the pair regularization path.
 - `adaptive_pair_steps::Int`: Steps handled by `:adaptive_cartesian`.
-- `lifted_pair_steps::Int`: Steps handled by `:lifted_pair` (Levi-Civita/KS).
+- `lifted_pair_steps::Int`: Steps handled by `:lifted_pair`
+  (1D square-root, 2D Levi-Civita, 3D KS).
 - `chain_steps::Int`: Steps handled by the chain (multi-pair) path.
 - `unregularized_steps::Int`: Steps taken in plain Cartesian coordinates.
 - `backend_fallback_steps::Int`: Steps where a fallback backend was used.
 - `total_substeps::Int`: Total regularized substeps across all macro-steps.
 - `max_substeps_used::Int`: Largest substep count used in any single macro-step.
 - `max_constraint_violation::Float64`: Maximum projection constraint residual observed.
+- `ks_constraint_projection_count::Int`: Number of KS momentum constraint projections.
+- `ks_constraint_iteration_count::Int`: Total KS projection iterations.
 - `min_encounter_distance::Float64`: Minimum pairwise separation seen during the solve.
 - `mode_history::Vector{UInt8}`: Per-step regularization mode (0=none, 1=pair, 2=chain).
 """
@@ -236,6 +240,8 @@ mutable struct RegularizationDiagnostics
     total_substeps::Int
     max_substeps_used::Int
     max_constraint_violation::Float64
+    ks_constraint_projection_count::Int
+    ks_constraint_iteration_count::Int
     min_encounter_distance::Float64
     mode_history::Vector{UInt8}
 
@@ -261,6 +267,8 @@ mutable struct RegularizationDiagnostics
             0,
             0,
             0.0,
+            0,
+            0,
             Inf,
             fill(REG_MODE_NONE, n_steps),
         )
@@ -328,6 +336,12 @@ mutable struct RegularizationBuffers
 
     ks_u::Vector{Float64}
     ks_U::Vector{Float64}
+    ks_u_mid::Vector{Float64}
+    ks_U_mid::Vector{Float64}
+    ks_du_tau::Vector{Float64}
+    ks_dU_tau::Vector{Float64}
+    ks_du_tau_mid::Vector{Float64}
+    ks_dU_tau_mid::Vector{Float64}
     ks_J::Matrix{Float64}
     ks_n::Vector{Float64}
 
@@ -410,6 +424,12 @@ mutable struct RegularizationBuffers
             Vector{Float64}(undef, 2),
             Vector{Float64}(undef, max(dims, 3)),
             Vector{Float64}(undef, max(dims, 3)),
+            Vector{Float64}(undef, 4),
+            Vector{Float64}(undef, 4),
+            Vector{Float64}(undef, 4),
+            Vector{Float64}(undef, 4),
+            Vector{Float64}(undef, 4),
+            Vector{Float64}(undef, 4),
             Vector{Float64}(undef, 4),
             Vector{Float64}(undef, 4),
             Matrix{Float64}(undef, 3, 4),
@@ -570,11 +590,62 @@ as read-only.
 """
 n_particles(prob::HamiltonianProblem) = n_particles(prob.system)
 dims(prob::HamiltonianProblem) = dims(prob.system)
+
+"""
+    n_pairs(sys_or_prob) -> Int
+
+Return the number of unordered particle pairs, `N*(N-1)/2`.
+"""
+n_pairs(sys::HamiltonianSystem) = n_particles(sys) * (n_particles(sys) - 1) ÷ 2
+n_pairs(prob::HamiltonianProblem) = n_pairs(prob.system)
+
+"""
+    pair_indices(sys_or_prob) -> Vector{Tuple{Int,Int}}
+
+Return all canonical particle pairs `(i, j)` with `i < j` in the same order
+used by `kappas(prob)` and [`kappa(prob, i, j)`](@ref). The order is
+`(1,2), (1,3), ..., (N-1,N)`.
+"""
+function pair_indices(sys::HamiltonianSystem)
+    n = n_particles(sys)
+    return [(i, j) for i = 1:n for j = (i+1):n]
+end
+pair_indices(prob::HamiltonianProblem) = pair_indices(prob.system)
+
+"""
+    masses(prob::HamiltonianProblem) -> AbstractVector{Float64}
+
+Return a read-only view of particle masses from `params(prob)`.
+"""
 masses(prob::HamiltonianProblem) = @view prob.params[1:n_particles(prob)]
+
+"""
+    charges(prob::HamiltonianProblem) -> AbstractVector{Float64}
+
+Return a read-only view of particle charges from `params(prob)`.
+"""
 charges(prob::HamiltonianProblem) =
     @view prob.params[(n_particles(prob)+1):(2*n_particles(prob))]
+
+"""
+    speed_of_light(prob::HamiltonianProblem) -> Float64
+
+Return the speed-of-light parameter `c`.
+"""
 speed_of_light(prob::HamiltonianProblem) = prob.params[2*n_particles(prob)+1]
+
+"""
+    kappas(prob::HamiltonianProblem) -> Vector{Float64}
+
+Return the backing vector of per-pair Zöllner coupling factors.
+"""
 kappas(prob::HamiltonianProblem) = prob.kappas
+
+"""
+    params(prob::HamiltonianProblem) -> Vector{Float64}
+
+Return the packed parameter vector `[masses; charges; c]`.
+"""
 params(prob::HamiltonianProblem) = prob.params
 
 """
@@ -695,9 +766,7 @@ end
 
 @inline function _resolve_regularization_backend(dims::Int, options::RegularizationOptions)
     requested = options.backend
-    if requested == REG_BACKEND_LIFTED && dims != 2
-        return REG_BACKEND_ADAPTIVE, true
-    end
+    dims in (1, 2, 3) || return REG_BACKEND_ADAPTIVE, requested == REG_BACKEND_LIFTED
     return requested, false
 end
 
@@ -800,14 +869,20 @@ run to completion. The current state is accessible via `integrator.q`,
 - `q::Vector{Float64}`: Current flattened positions.
 - `p::Vector{Float64}`: Current flattened momenta.
 - `step_count::Int`: Number of macro-steps completed so far.
+- `max_steps::Int`: Total macro-steps planned for the integration interval.
 - `buffers::SymmetricProjectionBuffers`: Pre-allocated workspace (internal).
 - `callbacks::Tuple`: Per-step callbacks (pre-/post-step hooks).
 - `diagnostics::RegularizationDiagnostics`: Live regularization statistics.
 - `t_history::Vector{Float64}`: Pre-allocated time history array.
 - `q_history::Vector{Vector{Float64}}`: Pre-allocated position history.
 - `p_history::Vector{Vector{Float64}}`: Pre-allocated momentum history.
+- `save_stride::Int`: Store every `save_stride`-th macro-step plus the final step.
+- `save_count::Int`: Number of history points stored so far.
+- `stream_sink`: Optional callable invoked as `(t, q, p, step)` for the initial
+  state and every completed macro-step. The sink must copy `q`/`p` if it
+  retains them.
 """
-mutable struct HamiltonianIntegrator{P<:HamiltonianProblem,A<:HamiltonianAlgorithm,C,CB<:Tuple}
+mutable struct HamiltonianIntegrator{P<:HamiltonianProblem,A<:HamiltonianAlgorithm,C,CB<:Tuple,S}
     prob::P
     alg::A
     t::Float64
@@ -815,12 +890,16 @@ mutable struct HamiltonianIntegrator{P<:HamiltonianProblem,A<:HamiltonianAlgorit
     q::Vector{Float64}
     p::Vector{Float64}
     step_count::Int
+    max_steps::Int
     buffers::C
     callbacks::CB
     diagnostics::RegularizationDiagnostics
     t_history::Vector{Float64}
     q_history::Vector{Vector{Float64}}
     p_history::Vector{Vector{Float64}}
+    save_stride::Int
+    save_count::Int
+    stream_sink::S
 end
 
 function Base.show(io::IO, int::HamiltonianIntegrator)

--- a/test/regression/capture.jl
+++ b/test/regression/capture.jl
@@ -261,8 +261,8 @@ function fixture_oned_kepler()
 end
 
 function fixture_threed_close_approach_adaptive()
-    # 3D analogue of close_approach_lifted, with the only 3D-supported backend
-    # (`:adaptive_cartesian`). Same 2-body parameters, embedded in the z=0
+    # 3D analogue of close_approach_lifted using the Cartesian substep backend.
+    # Same 2-body parameters, embedded in the z=0
     # plane to share an analytic structure with the 2D fixture.
     m1, m2 = 1.0, 0.1
     q1, q2 = sqrt(0.1), -sqrt(0.1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using WeberElectrodynamics: SymmetricProjectionIntegrator
 using LinearAlgebra
 using Random
 using Symbolics
+using JLD2
 
 @testset "WeberElectrodynamics.jl" begin
     include("test_utils.jl")
@@ -13,6 +14,7 @@ using Symbolics
     include("test_custom_hamiltonian.jl")
     include("test_named_term.jl")
     include("test_accessors.jl")
+    include("test_initial_conditions.jl")
     include("test_algorithm_dispatch.jl")
     include("test_regularized_integrator.jl")
     include("test_callbacks.jl")

--- a/test/test_accessors.jl
+++ b/test/test_accessors.jl
@@ -5,6 +5,8 @@
         @test n_particles(sys) == 3
         @test dims(sys) == 2
         @test degrees_of_freedom(sys) == 6
+        @test n_pairs(sys) == 3
+        @test pair_indices(sys) == [(1, 2), (1, 3), (2, 3)]
     end
 
     @testset "HamiltonianProblem parameter accessors" begin
@@ -25,6 +27,8 @@
         @test charges(prob) == [1.0, -1.0, 0.5]
         @test speed_of_light(prob) == 10.0
         @test kappas(prob) == ones(3)
+        @test n_pairs(prob) == 3
+        @test pair_indices(prob) == [(1, 2), (1, 3), (2, 3)]
 
         # params layout: [m₁…mₙ, q₁…qₙ, c]; kappas stored separately
         @test length(params(prob)) == 2*3 + 1

--- a/test/test_initial_conditions.jl
+++ b/test/test_initial_conditions.jl
@@ -1,0 +1,99 @@
+@testset "Initial-condition helpers" begin
+    function total_com(q, masses, dims)
+        out = zeros(dims)
+        for i in eachindex(masses)
+            for d = 1:dims
+                out[d] += masses[i] * q[(i-1)*dims+d]
+            end
+        end
+        return out
+    end
+
+    function total_momentum(p, n, dims)
+        out = zeros(dims)
+        for i = 1:n
+            for d = 1:dims
+                out[d] += p[(i-1)*dims+d]
+            end
+        end
+        return out
+    end
+
+    function pair_rdot(q, p, masses, dims, i, j)
+        rel_q = [q[(i-1)*dims+d] - q[(j-1)*dims+d] for d = 1:dims]
+        rel_v = [
+            p[(i-1)*dims+d] / masses[i] - p[(j-1)*dims+d] / masses[j] for
+            d = 1:dims
+        ]
+        return dot(rel_q, rel_v) / norm(rel_q)
+    end
+
+    @testset "center_of_mass_frame" begin
+        framed = center_of_mass_frame(
+            [2.0, 0.0, -1.0, 0.0],
+            [3.0, 0.0, -1.0, 0.0],
+            [1.0, 2.0],
+            2,
+        )
+
+        @test total_com(framed.q, [1.0, 2.0], 2) ≈ zeros(2)
+        @test total_momentum(framed.p, 2, 2) ≈ zeros(2) atol = 1e-14
+    end
+
+    @testset "two_body_initial_conditions" begin
+        ic = two_body_initial_conditions(
+            [1.0, 1.0],
+            [1.0, -1.0];
+            separation = 2.0,
+            dims = 2,
+            velocity_scale = 1.0,
+        )
+
+        @test ic.q ≈ [1.0, 0.0, -1.0, 0.0]
+        @test ic.p ≈ [0.0, 0.5, 0.0, -0.5]
+        @test total_com(ic.q, ic.masses, 2) ≈ zeros(2)
+        @test total_momentum(ic.p, 2, 2) ≈ zeros(2)
+        @test pair_rdot(ic.q, ic.p, ic.masses, 2, 1, 2) ≈ 0.0 atol = 1e-14
+    end
+
+    @testset "polygon_initial_conditions" begin
+        ic = polygon_initial_conditions(5; radius = 2.0, mass = 1.5)
+
+        @test length(ic.q) == 10
+        @test length(ic.p) == 10
+        @test ic.charges == [1.0, -1.0, 1.0, -1.0, 1.0]
+        @test total_com(ic.q, ic.masses, 2) ≈ zeros(2) atol = 1e-12
+        @test total_momentum(ic.p, 5, 2) ≈ zeros(2) atol = 1e-12
+        for i = 1:5, j = (i+1):5
+            @test pair_rdot(ic.q, ic.p, ic.masses, 2, i, j) ≈ 0.0 atol = 1e-12
+        end
+    end
+
+    @testset "rigid_rotation_initial_conditions" begin
+        q = [
+            1.0,
+            0.0,
+            0.0,
+            -0.5,
+            sqrt(3) / 2,
+            0.2,
+            -0.5,
+            -sqrt(3) / 2,
+            -0.4,
+        ]
+        masses = [1.0, 1.0, 1.0]
+        ic = rigid_rotation_initial_conditions(
+            q,
+            masses;
+            angular_velocity = [0.0, 0.0, 0.2],
+            dims = 3,
+            charges = [1.0, -1.0, 1.0],
+        )
+
+        @test total_com(ic.q, ic.masses, 3) ≈ zeros(3) atol = 1e-12
+        @test total_momentum(ic.p, 3, 3) ≈ zeros(3) atol = 1e-12
+        for i = 1:3, j = (i+1):3
+            @test pair_rdot(ic.q, ic.p, ic.masses, 3, i, j) ≈ 0.0 atol = 1e-12
+        end
+    end
+end

--- a/test/test_regularization.jl
+++ b/test/test_regularization.jl
@@ -78,7 +78,7 @@
     state_error(sol_a::HamiltonianSolution, sol_b::HamiltonianSolution) =
         norm(sol_a.q[end] - sol_b.q[end]) + norm(sol_a.p[end] - sol_b.p[end])
 
-    @testset "API and fallback" begin
+    @testset "API and lifted backend availability" begin
         sys2 = HamiltonianSystem(2, 2)
         q0_2d = [-1.0, 0.0, 1.0, 0.0]
         p0_2d = [0.0, -0.05, 0.0, 0.05]
@@ -118,28 +118,19 @@
         )
         int_fb = init(prob_fb, alg_fb)
         rb_fb = int_fb.buffers.regularization_buffers
-        @test rb_fb.effective_backend == WeberElectrodynamics.REG_BACKEND_ADAPTIVE
-        @test rb_fb.backend_fallback
+        @test rb_fb.effective_backend == WeberElectrodynamics.REG_BACKEND_LIFTED
+        @test !rb_fb.backend_fallback
 
         step!(int_fb)
-        @test int_fb.diagnostics.adaptive_pair_steps == 1
-        @test int_fb.diagnostics.lifted_pair_steps == 0
-        @test int_fb.diagnostics.backend_fallback_steps == 1
-
-        alg_warn = RegularizedIntegrator(
-            SymmetricProjectionIntegrator();
-            backend = :lifted_pair,
-            warn_on_fallback = true,
-            r_on = 0.2,
-            r_off = 0.26,
-        )
-        @test_logs (:warn, r"falling back to :adaptive_cartesian") init(prob_fb, alg_warn)
+        @test int_fb.diagnostics.lifted_pair_steps == 1
+        @test int_fb.diagnostics.adaptive_pair_steps == 0
+        @test int_fb.diagnostics.backend_fallback_steps == 0
     end
 
-    @testset "3D lifted pair fallback to adaptive_cartesian" begin
+    @testset "3D lifted pair uses KS backend" begin
         sys3 = HamiltonianSystem(2, 3)
         # Start within r_on (separation 0.16 < r_on 0.2) so regularization fires
-        # on the first step and backend_fallback_steps is immediately exercised.
+        # on the first step and the KS path is immediately exercised.
         q0_3d = [-0.08, 0.0, 0.0, 0.08, 0.0, 0.0]
         p0_3d = [0.0, -0.05, 0.0, 0.0, 0.05, 0.0]
 
@@ -162,24 +153,14 @@
         )
         int_3d = init(prob_3d, alg_3d)
         rb_3d = int_3d.buffers.regularization_buffers
-        @test rb_3d.effective_backend == WeberElectrodynamics.REG_BACKEND_ADAPTIVE
-        @test rb_3d.backend_fallback
+        @test rb_3d.effective_backend == WeberElectrodynamics.REG_BACKEND_LIFTED
+        @test !rb_3d.backend_fallback
 
         step!(int_3d)
-        @test int_3d.diagnostics.backend_fallback_steps == 1
-        @test int_3d.diagnostics.lifted_pair_steps == 0
-
-        alg_3d_warn = RegularizedIntegrator(
-            SymmetricProjectionIntegrator();
-            backend = :lifted_pair,
-            warn_on_fallback = true,
-            r_on = 0.2,
-            r_off = 0.3,
-        )
-        @test_logs (:warn, r"falling back to :adaptive_cartesian") init(
-            prob_3d,
-            alg_3d_warn,
-        )
+        @test int_3d.diagnostics.backend_fallback_steps == 0
+        @test int_3d.diagnostics.lifted_pair_steps == 1
+        @test int_3d.diagnostics.ks_constraint_projection_count > 0
+        @test int_3d.diagnostics.ks_constraint_iteration_count > 0
     end
 
     @testset "chain-disabled multi-pair encounter deactivates regularization" begin
@@ -292,6 +273,11 @@
                 c_err =
                     WeberElectrodynamics._ks_project_constraint!(rb.ks_U, rb.ks_u, rb.ks_n)
                 @test c_err < 1e-10
+
+                q_rel = zeros(3)
+                p_rel = zeros(3)
+                WeberElectrodynamics._ks_project!(q_rel, p_rel, rb.ks_u, rb.ks_U, J)
+                @test q_rel ≈ [x1, x2, x3] rtol = 1e-10 atol = 1e-10
             end
         end
     end

--- a/test/test_regularized_integrator.jl
+++ b/test/test_regularized_integrator.jl
@@ -29,4 +29,11 @@
         @test alg.options.warn_on_fallback === false
         @test alg.options.collision_bounce_radius == 0.01
     end
+
+    @testset "default base algorithm shorthand" begin
+        alg = WeberElectrodynamics.RegularizedIntegrator(; backend = :adaptive_cartesian)
+        @test alg.base_alg isa SymmetricProjectionIntegrator
+        @test alg.options.enabled === true
+        @test alg.options.backend === :adaptive_cartesian
+    end
 end

--- a/test/test_solve.jl
+++ b/test/test_solve.jl
@@ -124,6 +124,50 @@
         @test length(integrator.p_history) >= expected_steps
     end
 
+    @testset "save_stride stores sparse history and final state" begin
+        prob = make_weber_problem(tspan = (0.0, 0.1), dt = 0.01)
+        sol = solve(prob; save_stride = 4)
+
+        @test sol.retcode == :Success
+        @test sol.t ≈ [0.0, 0.04, 0.08, 0.1]
+        @test length(sol.q) == 4
+        @test length(sol.p) == 4
+
+        sol_alias = solve(prob; save_every = 5)
+        @test sol_alias.t ≈ [0.0, 0.05, 0.1]
+        @test_throws ArgumentError solve(prob; save_stride = 2, save_every = 5)
+        @test_throws ArgumentError solve(prob; save_stride = 0)
+    end
+
+    @testset "stream_sink receives every macro-step" begin
+        prob = make_weber_problem(tspan = (0.0, 0.03), dt = 0.01)
+        seen = Tuple{Float64,Int}[]
+        sink = (t, q, p, step) -> push!(seen, (t, step))
+
+        sol = solve(prob; save_stride = 10, stream_sink = sink)
+
+        @test sol.retcode == :Success
+        @test sol.t ≈ [0.0, 0.03]
+        @test first.(seen) ≈ [0.0, 0.01, 0.02, 0.03]
+        @test last.(seen) == [0, 1, 2, 3]
+    end
+
+    @testset "JLD2 solution archive helpers" begin
+        prob = make_weber_problem(tspan = (0.0, 0.02), dt = 0.01)
+        sol = solve(prob)
+        path = tempname() * ".jld2"
+
+        @test save_solution(path, sol; metadata = (case = "archive",)) == path
+        loaded = load_solution(path)
+
+        @test loaded isa HamiltonianSolution
+        @test loaded.t == sol.t
+        @test loaded.q == sol.q
+        @test loaded.p == sol.p
+        @test loaded.retcode == sol.retcode
+        rm(path; force = true)
+    end
+
     @testset "Two-body system solve" begin
         prob = make_coulomb_like_problem(tspan = (0.0, 1.0), dt = 0.01)
         sol = solve(prob)

--- a/test/test_statistics.jl
+++ b/test/test_statistics.jl
@@ -11,12 +11,17 @@ using WeberElectrodynamics: compute_total_kinetic_energy, compute_pair_weber_com
     @testset "TrajectoryData" begin
         @testset "compute_trajectory_data basic" begin
             traj = compute_trajectory_data(sol_coulomb, 2, 2)
+            inferred = compute_trajectory_data(sol_coulomb)
 
             @test traj isa TrajectoryData
+            @test inferred isa TrajectoryData
             @test traj.n_particles == 2
             @test traj.dims == 2
+            @test inferred.n_particles == 2
+            @test inferred.dims == 2
             @test length(traj.trajectories) == 2
             @test size(traj.trajectories[1]) == (length(sol_coulomb.t), 2)
+            @test inferred.trajectories[1] == traj.trajectories[1]
             @test length(traj.initial_positions) == 2
             @test length(traj.final_positions) == 2
             @test length(traj.initial_positions[1]) == 2
@@ -436,6 +441,17 @@ using WeberElectrodynamics: compute_total_kinetic_energy, compute_pair_weber_com
             @test length(momentum.linear_momentum_magnitude) == length(sol_weber.t)
             @test momentum.n_particles == 2
             @test momentum.dims == 2
+        end
+
+        @testset "conservation_summary" begin
+            summary = conservation_summary(sol_weber; stride = 10)
+
+            @test summary.n_points == length(1:10:length(sol_weber.t))
+            @test summary.energy.global_error_percent_max >= 0
+            @test summary.energy.hamiltonian_validation_max >= 0
+            @test summary.momentum.linear_drift_max >= 0
+            @test summary.min_pair_distance > 0
+            @test summary.regularization === sol_weber.regularization
         end
 
         @testset "Linear momentum components" begin

--- a/theory/InitialConditions.md
+++ b/theory/InitialConditions.md
@@ -581,7 +581,7 @@ Simulation parameters should be chosen accordingly:
 - $\mathrm{tspan}$: several multiples of $T$ to capture multiple oscillation cycles.
 - $\mathrm{dt}$: small enough to resolve the oscillation; at least 20 steps per period.
 
-**Regularization.** As $r \to 0$ the radial velocity approaches $\sqrt{2}\,c$ and the Coulomb singularity $k/r$ diverges. Regularization (see [Regularization.md](Regularization.md)) is essential for accurate integration. Use `:adaptive_cartesian` for 3D or `:lifted_pair` for 2D.
+**Regularization.** As $r \to 0$ the radial velocity approaches $\sqrt{2}\,c$ and the Coulomb singularity $k/r$ diverges. Regularization (see [Regularization.md](Regularization.md)) is essential for accurate integration. Use `:lifted_pair` for binary 1D/2D/3D close encounters or `:adaptive_cartesian` when a Cartesian substep path is preferred.
 
 ## Distant-State Like-Charge Scattering
 
@@ -621,11 +621,11 @@ $$v = \eta_{\text{orb}} \cdot v_{\text{orb}}$$
 
 Bound orbits require $\eta_{\text{orb}} \lesssim 0.9$; at $\eta_{\text{orb}} \geq 1$ the orbiter escapes. The exact bound/unbound threshold depends on the nucleus size and Zöllner coupling.
 
-**Collision bounce.** The nucleus pair oscillation passes through $r = 0$ (in the $\ell = 0$ regularisable case). Use a collision bounce radius $r_{\text{bounce}} > 0$ to reflect the relative coordinate at small separation (see [../exploratory/CollisionBounceRegularization.md](../exploratory/CollisionBounceRegularization.md)).
+**Collision bounce.** The nucleus pair oscillation passes through $r = 0$ (in the $\ell = 0$ regularisable case). Use a collision bounce radius $r_{\text{bounce}} > 0$ to reflect the relative coordinate at small separation. The package-level callback and regularized-integrator bridge are documented in [docs/src/regularization.md](../docs/src/regularization.md).
 
 **Zöllner enhancement.** With mismatch parameter $a > 0$, the unlike-pair coupling strengthens by factor $(1+a)$. This tightens the orbiter's orbit and can circularise an otherwise eccentric trajectory. For $\eta_{\text{orb}} = 0.8$ and $a = 0.5$, the orbit becomes nearly circular. The nucleus (like-charge pair) is unaffected by $a$ since $\kappa_{ij} = 1$ for like signs.
 
-This construction is approximate: the nucleus oscillation and orbital motion couple dynamically. The scale separation $R \gg r_{\text{nuc}}$ controls the quality of the approximation. Validated configurations and parameter sweeps are documented in [../exploratory/ThreeBodyBoundStates.md](../exploratory/ThreeBodyBoundStates.md).
+This construction is approximate: the nucleus oscillation and orbital motion couple dynamically. The scale separation $R \gg r_{\text{nuc}}$ controls the quality of the approximation. Treat parameter sweeps as simulation studies rather than closed-form guarantees.
 
 ## Reference Tables
 

--- a/theory/RegularizedIntegrationDesign.md
+++ b/theory/RegularizedIntegrationDesign.md
@@ -16,21 +16,18 @@ Regularization backend is configured through `RegularizedIntegrator(base_alg; ba
 - `:lifted_pair`
 - `:adaptive_cartesian`
 
-Effective backend is resolved at init:
-
-- 2D: requested backend is honored.
-- 1D/3D with requested `:lifted_pair`: fallback to `:adaptive_cartesian`.
-
-Fallback behavior:
+Effective backend is resolved at init. For supported dimensions (`1`, `2`, and
+`3`), both configured backends are available for binary pair mode. Fallback
+behavior is reserved for unsupported future dimensions:
 
 - one init-time warning when `warn_on_fallback=true`
 - diagnostics counter increment on fallback pair steps
 
 Support matrix:
 
-- 2D pair mode: true lifted pair backend available
-- 1D pair mode: adaptive Cartesian backend
-- 3D pair mode: adaptive Cartesian backend
+- 1D pair mode: lifted square-root or adaptive Cartesian backend
+- 2D pair mode: lifted Levi-Civita or adaptive Cartesian backend
+- 3D pair mode: lifted KS or adaptive Cartesian backend
 - chain mode (all dims): adaptive Cartesian backend
 
 ## Encounter Dispatch and Hysteresis
@@ -66,12 +63,12 @@ The adaptive Cartesian pair backend keeps the previous robust path:
 3. For each substep, run the existing projected Cartesian kernel.
 4. In 3D, apply KS constraint projection in lifted diagnostics path.
 
-## Pair Mode: `:lifted_pair` (2D)
+## Pair Mode: `:lifted_pair`
 
-2D lifted pair mode uses a split method:
+Lifted pair mode uses a split method:
 
 - `A`: external perturbation half-step (physical time, midpoint)
-- `B`: lifted pair full-step (LC coordinates)
+- `B`: lifted pair full-step (1D square-root, 2D LC, or 3D KS coordinates)
 - `A`: external perturbation half-step
 
 ### Derivative decomposition
@@ -132,13 +129,17 @@ Chain mode uses adaptive Cartesian integration:
 
 ## KS Constraint Handling
 
-3D regularized paths still use KS diagnostics support in adaptive Cartesian mode:
+3D regularized paths have two KS-related modes:
 
-- lift to KS variables for active pair checks
-- project momentum to satisfy bilinear KS constraint
-- track max constraint violation in diagnostics
+- `:lifted_pair` uses a KS pair chart with fictitious time for binary close
+  encounters.
+- `:adaptive_cartesian` still lifts to KS variables for active-pair diagnostics,
+  projects momentum to satisfy the bilinear KS constraint, and then advances the
+  Cartesian projected kernel.
+- Diagnostics track max constraint violation plus KS projection/iteration counts.
 
-True 3D lifted KS stepping is deferred to a future release.
+True chain-coordinate KS regularization for multi-particle clusters remains
+deferred; chain mode is adaptive Cartesian over the active component.
 
 ## Diagnostics
 
@@ -151,6 +152,7 @@ True 3D lifted KS stepping is deferred to a future release.
 - `backend_fallback_steps`
 - `total_substeps`, `max_substeps_used`
 - `min_encounter_distance`, `max_constraint_violation`
+- `ks_constraint_projection_count`, `ks_constraint_iteration_count`
 - per-step mode history (`0` Cartesian, `1` pair, `2` chain)
 
 `used_backend` semantics:


### PR DESCRIPTION
This PR introduces several significant enhancements and bug fixes:

### Major Features
- **3D KS Regularization**: Added Kustaanheimo-Stiefel (KS) lifted-pair backend for analytical resolution of 3D close encounters.
- **Parametric Type Refactor**: `HamiltonianProblem`, `HamiltonianSolution`, and `HamiltonianIntegrator` are now parametric, significantly improving performance and reducing dynamic dispatch.
- **Sparse Saving & Streaming**: Added `save_stride` and `stream_sink` support to the solver for better memory management and real-time processing.
- **1D Regularization**: Added a dedicated 1D lifted-pair backend for head-on collisions.

### Utilities & Statistics
- **Conservation Summary**: New helper for quick verification of simulation quality.
- **Solution Archiving**: JLD2-based save/load helpers for solutions.
- **Initial Conditions**: New builders for common Weber configurations.

### Bug Fixes
- Corrected time-offset accumulation in regularized substeps.
- Handled LC map singularity at the origin.
- Fixed Zöllner coupling logic for neutral particles.
- Improved animation dashboard stability and circular buffer handling.

This PR also includes release notes for the upcoming v0.5.1 release.