### PR TITLE
docs: clarify collision bounce regularization

### DIFF
--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -82,15 +82,17 @@ Only two valid values for `RegularizationOptions.backend`:
 - `:lifted_pair` — lifted square-root (1D), Levi-Civita (2D), or KS (3D) binary pair stepping
 
 Multi-particle close clusters use chain mode, which is adaptive Cartesian over
-the active component. Neither backend analytically regularizes Weber's
-velocity-dependent force — only the Coulomb/Kepler singularity.
+the active component rather than analytic chain-coordinate regularization.
+Neither backend analytically regularizes Weber's velocity-dependent force —
+only the Coulomb/Kepler singularity.
 
 ### Collision bounce
 
 - Implemented as the `CollisionBounce(radius)` callback; pass it to `solve` (or `init`) via the `callbacks` kwarg
 - `RegularizedIntegrator` also accepts a `collision_bounce_radius` kwarg and synthesises a matching callback automatically when no `CollisionBounce` is supplied
 - Under `RegularizedIntegrator`, the bounce radius is checked after regularized substeps as well as at macro-step boundaries
-- Only valid for ℓ=0 (head-on) collisions
+- Geometric and charge-sign agnostic: it reflects any pair inside the radius, including two-body unlike-charge pass-through when explicitly enabled
+- Only valid for `L = 0` head-on, C0-continuable collisions/pass-through events; it is not generally energy-preserving for `N > 2`
 
 ### Zöllner extension
 

--- a/docs/src/regularization.md
+++ b/docs/src/regularization.md
@@ -96,12 +96,18 @@ regularization enters chain mode (adaptive Cartesian substeps for the whole
 cluster). Chain mode is enabled by default; disable with
 `RegularizedIntegrator(...; chain_enabled = false)`.
 
+Chain mode does not implement analytic chain-coordinate regularization; it is a
+Cartesian fallback for multi-pair clusters.
+
 ## Collision bounce
 
-For head-on (ℓ = 0) collisions between like-charge pairs, a reflection boundary
-can be applied before each macro-step. Under `RegularizedIntegrator`, the same
-radius is also checked after regularized substeps, so close approaches inside a
-regularized macro-step do not have to wait for the next outer step.
+For head-on (`L = 0`) collisions or pass-through events, a reflection boundary
+can be applied before each macro-step. The bounce is geometric rather than
+charge-sign-specific: it reflects any pair inside the radius, including a
+two-body unlike-charge pair when explicitly enabled. Under
+`RegularizedIntegrator`, the same radius is also checked after regularized
+substeps, so close approaches inside a regularized macro-step do not have to
+wait for the next outer step.
 
 Collision bounce is a [`CollisionBounce`](@ref) callback; pass it through the
 `callbacks` kwarg of `solve` (or `init`):
@@ -120,8 +126,10 @@ alg = RegularizedIntegrator(SymmetricProjectionIntegrator();
 sol = solve(prob, alg)
 ```
 
-Collision bounce is intended for C0-continuable head-on cases. It does not make
-generic nonzero-angular-momentum collisions regular.
+Collision bounce is intended for C0-continuable head-on cases. It preserves the
+isolated two-body pair energy exactly, but it is not generally energy-preserving
+for `N > 2` because reflected particles move relative to third bodies. It does
+not make generic nonzero-angular-momentum collisions regular.
 
 ## Diagnostics
 

--- a/examples/unlike_collision_bounce.ipynb
+++ b/examples/unlike_collision_bounce.ipynb
@@ -1,0 +1,173 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Unlike-Charge Collision Bounce Demo\n",
+    "\n",
+    "This notebook demonstrates a head-on pair with charges `+1` and `-1` in 2D. The pair is integrated with `RegularizedIntegrator(...; backend = :lifted_pair)` and `collision_bounce_radius`, so close approaches use the lifted pair backend and the geometric bounce provides the explicit pass-through continuation near `r = 0`.\n",
+    "\n",
+    "The bounce is intended for `L = 0` head-on cases. It is not a generic cure for nonzero-angular-momentum collisions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "using WeberElectrodynamics\n",
+    "using LinearAlgebra: norm\n",
+    "using Printf: @printf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "The two particles start at rest on the x-axis. With unlike charges, they accelerate toward each other, pass through the bounce radius, and repeat as a bounded head-on oscillation in this explicitly reflected model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = 1.0\n",
+    "qmag = 1.0\n",
+    "c = 100.0\n",
+    "r0 = 0.25\n",
+    "dt = 5e-5\n",
+    "bounce_r = 0.006\n",
+    "\n",
+    "sys = HamiltonianSystem(2, 2)\n",
+    "prob = HamiltonianProblem(\n",
+    "    sys,\n",
+    "    (0.0, 1.0),\n",
+    "    [r0 / 2, 0.0, -r0 / 2, 0.0],\n",
+    "    zeros(4);\n",
+    "    masses = [m, m],\n",
+    "    charges = [qmag, -qmag],\n",
+    "    c = c,\n",
+    "    dt = dt,\n",
+    "    maximum_iterations = 200,\n",
+    ")\n",
+    "\n",
+    "alg = RegularizedIntegrator(\n",
+    "    SymmetricProjectionIntegrator();\n",
+    "    backend = :lifted_pair,\n",
+    "    r_on = 0.03,\n",
+    "    r_off = 0.05,\n",
+    "    max_substeps = 4096,\n",
+    "    collision_bounce_radius = bounce_r,\n",
+    "    warn_on_fallback = false,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Solve"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sol = solve(prob, alg; save_stride = 10)\n",
+    "diag = sol.regularization\n",
+    "\n",
+    "@printf \"retcode              = %s\\n\" sol.retcode\n",
+    "@printf \"saved points          = %d\\n\" length(sol.t)\n",
+    "@printf \"used backend          = %s\\n\" diag.used_backend\n",
+    "@printf \"lifted pair steps     = %d\\n\" diag.lifted_pair_steps\n",
+    "@printf \"total substeps        = %d\\n\" diag.total_substeps\n",
+    "@printf \"min encounter distance = %.6e\\n\" diag.min_encounter_distance"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Diagnostics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "separation(q) = sqrt((q[1] - q[3])^2 + (q[2] - q[4])^2)\n",
+    "rs = separation.(sol.q)\n",
+    "x1 = getindex.(sol.q, 1)\n",
+    "x2 = getindex.(sol.q, 3)\n",
+    "\n",
+    "energy = compute_energy_timeseries(sol)\n",
+    "relative_energy_error =\n",
+    "    (energy.total_energy .- energy.total_energy[1]) ./ abs(energy.total_energy[1]) .* 100\n",
+    "n_close_passes = count(k -> rs[k] < rs[k-1] && rs[k] < rs[k+1], 2:(length(rs)-1))\n",
+    "\n",
+    "@printf \"min separation        = %.6e\\n\" minimum(rs)\n",
+    "@printf \"max separation        = %.6e\\n\" maximum(rs)\n",
+    "@printf \"close-pass minima     = %d\\n\" n_close_passes\n",
+    "@printf \"max energy drift      = %.6e %%\\n\" maximum(abs, relative_energy_error)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Optional Plots\n",
+    "\n",
+    "Run this cell if `Plots.jl` is available in the active Julia environment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "using Plots\n",
+    "\n",
+    "p_sep = plot(sol.t, rs; xlabel = \"t\", ylabel = \"r12\", label = \"separation\")\n",
+    "hline!(p_sep, [bounce_r]; label = \"bounce radius\", linestyle = :dash)\n",
+    "\n",
+    "p_x = plot(sol.t, x1; xlabel = \"t\", ylabel = \"x\", label = \"particle 1\")\n",
+    "plot!(p_x, sol.t, x2; label = \"particle 2\")\n",
+    "\n",
+    "p_e = plot(\n",
+    "    energy.t,\n",
+    "    relative_energy_error;\n",
+    "    xlabel = \"t\",\n",
+    "    ylabel = \"energy drift (%)\",\n",
+    "    label = \"relative drift\",\n",
+    ")\n",
+    "\n",
+    "plot(p_sep, p_x, p_e; layout = (3, 1), size = (900, 800))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Julia",
+   "language": "julia",
+   "name": "julia"
+  },
+  "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
+   "name": "julia"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -35,11 +35,11 @@ apply_post_step!(::HamiltonianCallback, _, _::Float64) = nothing
     CollisionBounce(radius)
 
 Pre-step callback that reflects the relative coordinate of any pair closer
-than `radius` through the origin, preserving COM and momenta (C⁰-continuation
-of the ℓ = 0 head-on collision; Frauenfelder & Weber 2024). Works best with
-the unregularized symplectic path. Under `RegularizedIntegrator`, the callback
-fires only at macro-step boundaries; close approaches inside regularized
-substeps are not reflected until the next outer step.
+than `radius` through the origin, preserving COM and momenta (C0-continuation
+of an `L = 0` head-on collision or pass-through; Frauenfelder & Weber 2024).
+The callback itself fires at macro-step boundaries. Under `RegularizedIntegrator`,
+the same radius is also checked after regularized pair/chain substeps through
+the regularized step path.
 
 See `docs/src/regularization.md` and `theory/Regularization.md` for the
 regularization and collision-continuation context.

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -658,10 +658,11 @@ end
     return sqrt(dx * dx + dy * dy)
 end
 
-# Reflect the relative coordinate through the origin while leaving
-# momenta unchanged.  Physically this is the two particles passing
-# through each other at r = 0 (C⁰-continuation of the ℓ = 0 collision).
-# Energy is exactly preserved because H depends only on |q_rel| and p_rel.
+# Reflect the relative coordinate through the origin while leaving momenta
+# unchanged. Physically this is the two particles passing through each other
+# at r = 0 (C0-continuation of an L = 0 collision). For an isolated two-body
+# pair Hamiltonian, energy is preserved because H depends only on |q_rel| and
+# p_rel; in N > 2 systems this is only a local pair continuation.
 @inline function _reflect_pair_2d!(
     q::Vector{Float64},
     p::Vector{Float64},
@@ -1852,9 +1853,9 @@ function _resolve_callbacks(::HamiltonianProblem, ::HamiltonianAlgorithm, cbs)
     return _normalise_callbacks(cbs)
 end
 
-# Pre-step collision bounce: for each pair closer than bounce_r,
-# reflect the relative coordinate through the origin.
-# Used for like-charge sub-critical oscillation (ℓ=0, C⁰-continuable).
+# Pre-step collision bounce: for each pair closer than bounce_r, reflect the
+# relative coordinate through the origin. This is intended for explicitly
+# selected head-on (L = 0, C0-continuable) collisions or pass-through events.
 @inline function _apply_collision_bounces!(
     q::Vector{Float64},
     masses::AbstractVector{Float64},

--- a/test/test_callbacks.jl
+++ b/test/test_callbacks.jl
@@ -6,6 +6,37 @@
         @test_throws AssertionError CollisionBounce(-0.1)
     end
 
+    @testset "CollisionBounce reflects unlike-charge head-on pairs" begin
+        sys = HamiltonianSystem(2, 2)
+        q0 = [0.004, 0.0, -0.004, 0.0]
+        p0 = [0.1, -0.2, -0.3, 0.4]
+        prob = HamiltonianProblem(
+            sys,
+            (0.0, 0.02),
+            q0,
+            p0;
+            masses = [1.0, 1.0],
+            charges = [1.0, -1.0],
+            c = 100.0,
+            dt = 0.01,
+        )
+        cb = CollisionBounce(0.02)
+        integrator = init(prob, SymmetricProjectionIntegrator(); callbacks = cb)
+
+        rel_before = integrator.q[1:2] .- integrator.q[3:4]
+        com_before = 0.5 .* (integrator.q[1:2] .+ integrator.q[3:4])
+        p_before = copy(integrator.p)
+
+        apply_pre_step!(cb, integrator, prob.dt)
+
+        rel_after = integrator.q[1:2] .- integrator.q[3:4]
+        com_after = 0.5 .* (integrator.q[1:2] .+ integrator.q[3:4])
+
+        @test rel_after ≈ -rel_before
+        @test com_after ≈ com_before
+        @test integrator.p == p_before
+    end
+
     @testset "default callbacks are empty" begin
         sys = HamiltonianSystem(2, 2)
         prob = HamiltonianProblem(

--- a/test/test_regularization.jl
+++ b/test/test_regularization.jl
@@ -647,6 +647,52 @@
         @test en.statistics.global_error_percent_max < 1.0
     end
 
+    @testset "Unlike-charge head-on bounce with lifted regularization" begin
+        m1 = m2 = 1.0
+        q1, q2 = 1.0, -1.0
+        c = 100.0
+        r0 = 0.25
+
+        sys = HamiltonianSystem(2, 2)
+        prob = HamiltonianProblem(
+            sys,
+            (0.0, 0.25),
+            [r0 / 2, 0.0, -r0 / 2, 0.0],
+            zeros(4);
+            masses = [m1, m2],
+            charges = [q1, q2],
+            c = c,
+            dt = 1e-4,
+            maximum_iterations = 200,
+        )
+        alg = RegularizedIntegrator(
+            SymmetricProjectionIntegrator();
+            backend = :lifted_pair,
+            warn_on_fallback = false,
+            r_on = 0.03,
+            r_off = 0.05,
+            max_substeps = 4096,
+            collision_bounce_radius = 0.006,
+        )
+
+        sol = solve(prob, alg)
+        @test sol.retcode == :Success
+        @test all(isfinite, sol.q[end])
+        @test all(isfinite, sol.p[end])
+        @test sol.regularization.lifted_pair_steps > 0
+
+        rs = [
+            sqrt((sol.q[k][1] - sol.q[k][3])^2 + (sol.q[k][2] - sol.q[k][4])^2) for
+            k = 1:length(sol.t)
+        ]
+        n_minima = count(k -> rs[k] < rs[k-1] && rs[k] < rs[k+1], 2:(length(rs)-1))
+        @test minimum(rs) < 0.01
+        @test n_minima >= 1
+
+        en = compute_energy_timeseries(sol)
+        @test en.statistics.global_error_percent_max < 1.0
+    end
+
     @testset "Chain mode correctness" begin
         sys = HamiltonianSystem(3, 2)
         q0 = [-0.12, 0.0, 0.0, 0.0, 0.12, 0.0]

--- a/theory/Regularization.md
+++ b/theory/Regularization.md
@@ -7,7 +7,7 @@ Regularization removes collision singularities in pairwise $1/r$-type interactio
 1. Replace singular relative coordinates by collision-resolving coordinates.
 2. Rescale physical time so trajectories slow down near collisions in physical time but remain smooth in a fictitious time.
 
-This document is self-contained and independent of any specific implementation.
+This document is self-contained and independent of any specific implementation. For Weber electrodynamics, these lifted maps analytically regularize the Coulomb/Kepler $1/r$ singularity only; Weber's velocity-dependent correction must still be handled by the numerical equations of motion or by a separate collision-continuation rule.
 
 ## Singular Structure of the $N$-Body Problem
 
@@ -261,7 +261,7 @@ In numerical $N$-body work, regularization is typically activated only for close
 1. Detect candidate close pairs with an activation radius $r_{\text{on}}$.
 2. Keep regularization active until all relevant separations exceed a larger radius $r_{\text{off}}>r_{\text{on}}$ (hysteresis).
 3. If the active encounter involves one close binary, apply pair regularization directly.
-4. If several close pairs share particles (overlapping encounter graph), switch to a local chain-style subsystem and evolve it with a global monitor $g$ (for example $g=1/\Omega$).
+4. If several close pairs share particles (overlapping encounter graph), switch to a local chain-style subsystem and evolve it with a global monitor $g$ (for example $g=1/\Omega$), or use adaptive Cartesian substepping when analytic chain regularization is not implemented.
 
 This practical policy preserves the main benefit of regularization near singular events while keeping the far-field integration in ordinary coordinates.
 
@@ -275,15 +275,29 @@ When several nearby bodies interact simultaneously, direct pairwise relative coo
 
 This reduces subtraction of large nearby numbers and improves robustness in few-body subsystems embedded in large $N$-body dynamics.
 
+In WeberElectrodynamics.jl, chain coordinates are background theory rather than the implemented chain backend: multi-particle close clusters currently use adaptive Cartesian substeps over the active component, while true analytic chain-coordinate regularization remains deferred.
+
+## Collision-Bounce Continuation
+
+For $L=0$ head-on collisions that are $C^0$-continuable, a practical collision bounce reflects the relative coordinate through the origin while preserving the center of mass and momenta:
+
+$$
+\vec r_{ij}\mapsto -\vec r_{ij},\quad P_{ij}\mapsto P_{ij},\quad p_{ij}\mapsto p_{ij}.
+$$
+
+For an isolated two-body Hamiltonian whose potential depends only on $r_{ij}$, this preserves energy exactly because $r_{ij}$ and the momenta are unchanged in magnitude. In an $N>2$ system, reflecting one pair can change distances to third particles, so it should be treated as a local continuation device rather than an exact full-system energy-preserving map.
+
+The same geometric bounce can be used for unlike-charge head-on pass-through when explicitly enabled. It is not a substitute for regularization of nonzero-angular-momentum collisions.
+
 ## Key Mathematical Outcomes
 
-- Binary collision singularities are removed from the transformed vector field.
+- The Coulomb/Kepler binary collision singularity is removed from the transformed vector field.
 - Physical time is recovered by integrating $\frac{dt}{d\tau}=g$.
 - Canonical structure is preserved by coordinate maps plus extended-phase-space Hamiltonian flow.
 - 1D, 2D, and 3D binary regularizations share the same pattern:
   singular radius $r$ becomes quadratic in regularized coordinates and is canceled by $dt=r\,d\tau$.
-- In $N$-body systems, regularization is exact for isolated binary collisions and remains effective for close-encounter subsystems with suitable global $g$ and coordinate organization.
-- **Weber like-charge collisions.** For two like charges inside the critical radius $\rho$, regularizability depends on angular momentum. Head-on collisions ($\ell = 0$) reach the origin at finite speed $\sqrt{2}\,c$ and are $C^0$-continuable — amenable to the techniques above. Spiraling collisions ($\ell \neq 0$) reach the origin at infinite speed in finite time and are *not* regularizable by any smooth coordinate-time transform (Frauenfelder & Weber 2024, Theorem 2.1). The obstruction is topological: infinite winding number, preserved by all smooth coordinate changes.
+- In $N$-body systems, regularization is exact for isolated Coulomb/Kepler binary collisions and remains effective for close-encounter subsystems with suitable global $g$ and coordinate organization.
+- **Weber collision limits.** For two like charges inside the critical radius $\rho$, regularizability depends on angular momentum. Head-on collisions ($\ell = 0$) reach the origin at finite speed $\sqrt{2}\,c$ and are $C^0$-continuable. Spiraling collisions ($\ell \neq 0$) reach the origin at infinite speed in finite time and are *not* regularizable by any smooth coordinate-time transform (Frauenfelder & Weber 2024, Theorem 2.1). The obstruction is topological: infinite winding number, preserved by all smooth coordinate changes.
 
 ## References
 

--- a/theory/RegularizedIntegrationDesign.md
+++ b/theory/RegularizedIntegrationDesign.md
@@ -119,7 +119,9 @@ The frozen-per-substep monitor avoids distortion from re-scaling midpoint stages
 
 ## Chain Mode
 
-Chain mode uses adaptive Cartesian integration:
+Chain mode uses adaptive Cartesian integration. It does not implement analytic
+chain-coordinate regularization; the chain ordering is used to define and
+diagnose the close cluster while the actual step remains Cartesian:
 
 1. Build deterministic chain ordering from closest-link traversal.
 2. Compute active-component monitor
@@ -167,9 +169,16 @@ deferred; chain mode is adaptive Cartesian over the active component.
 `RegularizationOptions` accepts `collision_bounce_radius::Float64 = 0.0`
 (disabled by default). When positive, a pre-step reflection is applied to any
 pair closer than this radius: `q_rel → -q_rel` with momenta unchanged. This is
-the C⁰-continuation of a head-on (ℓ=0) collision and preserves energy exactly.
+the C0-continuation of a head-on (`L = 0`) collision or pass-through, including
+two-body unlike-charge pairs when explicitly enabled. For an isolated two-body
+Hamiltonian whose pair potential depends only on `|q_rel|`, the reflection
+preserves energy exactly; in `N > 2`, distances to third particles can change,
+so the bounce is not generally an exact full-system energy-preserving map.
+
 The feature is independent of the regularization backend and may be used with
-`enabled = false`.
+`enabled = false`. Under `RegularizedIntegrator`, the bounce radius is checked
+at macro-step boundaries through the callback path and after regularized
+substeps inside pair/chain macro-steps.
 
 ## Memory Model
 


### PR DESCRIPTION
## Summary
- Clarify regularization docs around Coulomb-only analytic lifting, adaptive Cartesian chain mode, and generic head-on bounce behavior.
- Document unlike-charge pass-through support through the existing geometric CollisionBounce path.
- Add unlike-charge bounce regression coverage and a cleared example notebook.

## Tests
- python3 -m json.tool examples/unlike_collision_bounce.ipynb
- git diff --check
- targeted callback tests: 36 of 36 passed
- targeted regularization tests: 487 of 487 passed
- full package test suite: 20776 of 20776 passed